### PR TITLE
use compareAndSet on isShuttingDown to avoid executing stop twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.1] - 2021-08-12
+### Changes
+* use `compareAndSet` to avoid `stop` from executing twice in GracefulShutdowner
+
 ## [2.3.0] - 2021-05-28
 ### Changed
 * Moved from JDK 8 to JDK 11.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=2.3.0
+version=2.3.1


### PR DESCRIPTION
## Context

There might be a possibility for `stop` being executed twice as the critical section is not synchronised

### Changes

used `compareAndSet` to make the operation atomic

## Checklist
- [x] I have considered the impact of this change and added a [Change Classification](
https://transferwise.atlassian.net/wiki/spaces/EKB/pages/1401189673/Change+Classifications+and+Expectations) Label (`change:standard`, `change:impactful`, `change:emergency`)
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
