### PR TITLE
Added a shutdown strategy for db-scheduler 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.0] - 2021-08-12
+### Changes
+* Added strategy for graceful shutdown of db-scheduler beans 
+
 ## [2.3.1] - 2021-08-12
 ### Changes
 * use `compareAndSet` to avoid `stop` from executing twice in GracefulShutdowner

--- a/build.libraries.gradle
+++ b/build.libraries.gradle
@@ -16,5 +16,7 @@ ext {
             springBootConfigurationProcessor: 'org.springframework.boot:spring-boot-configuration-processor',
             springBootStarter               : 'org.springframework.boot:spring-boot-starter',
             springBootStarterTest           : 'org.springframework.boot:spring-boot-starter-test',
+            dbSchedulerSpringBootStarter    : 'com.github.kagkarlsson:db-scheduler-spring-boot-starter:11.0'
+
     ]
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -14,6 +14,8 @@ dependencies {
     implementation libraries.springBootActuator
     implementation libraries.springWeb
     implementation libraries.guava
+    implementation libraries.dbSchedulerSpringBootStarter
+
 
     compileOnly libraries.springContext
     compileOnly libraries.javaxServletApi

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -14,9 +14,8 @@ dependencies {
     implementation libraries.springBootActuator
     implementation libraries.springWeb
     implementation libraries.guava
-    implementation libraries.dbSchedulerSpringBootStarter
 
-
+    compileOnly libraries.dbSchedulerSpringBootStarter
     compileOnly libraries.springContext
     compileOnly libraries.javaxServletApi
     compileOnly libraries.slf4jApi

--- a/core/src/main/java/com/transferwise/common/gracefulshutdown/GracefulShutdownAutoConfiguration.java
+++ b/core/src/main/java/com/transferwise/common/gracefulshutdown/GracefulShutdownAutoConfiguration.java
@@ -1,7 +1,9 @@
 package com.transferwise.common.gracefulshutdown;
 
+import com.github.kagkarlsson.scheduler.Scheduler;
 import com.transferwise.common.gracefulshutdown.config.GracefulShutdownProperties;
 import com.transferwise.common.gracefulshutdown.config.RequestCountStrategyProperties;
+import com.transferwise.common.gracefulshutdown.config.ScheduledTaskShutdownStrategy;
 import com.transferwise.common.gracefulshutdown.strategies.GracefulShutdownHealthStrategy;
 import com.transferwise.common.gracefulshutdown.strategies.RequestCountGracefulShutdownStrategy;
 import lombok.RequiredArgsConstructor;
@@ -59,6 +61,12 @@ public class GracefulShutdownAutoConfiguration {
     public RequestCountGracefulShutdownStrategy requestCountGracefulShutdownStrategy() {
       return new RequestCountGracefulShutdownStrategy();
     }
+  }
+
+  @Bean
+  @ConditionalOnProperty(value = "tw-graceful-shutdown.db-scheduler.enabled")
+  public ScheduledTaskShutdownStrategy scheduledTaskShutdownStrategy(final Scheduler scheduler) {
+    return new ScheduledTaskShutdownStrategy(scheduler);
   }
 
   @Bean

--- a/core/src/main/java/com/transferwise/common/gracefulshutdown/GracefulShutdownAutoConfiguration.java
+++ b/core/src/main/java/com/transferwise/common/gracefulshutdown/GracefulShutdownAutoConfiguration.java
@@ -63,11 +63,7 @@ public class GracefulShutdownAutoConfiguration {
     }
   }
 
-  @Bean
-  @ConditionalOnProperty(value = "tw-graceful-shutdown.db-scheduler.enabled")
-  public ScheduledTaskShutdownStrategy scheduledTaskShutdownStrategy(final Scheduler scheduler) {
-    return new ScheduledTaskShutdownStrategy(scheduler);
-  }
+
 
   @Bean
   @ConditionalOnMissingBean

--- a/core/src/main/java/com/transferwise/common/gracefulshutdown/GracefulShutdownAutoConfiguration.java
+++ b/core/src/main/java/com/transferwise/common/gracefulshutdown/GracefulShutdownAutoConfiguration.java
@@ -22,63 +22,63 @@ import org.springframework.context.annotation.Configuration;
 @AutoConfigureAfter(name = {"org.springframework.cloud.netflix.eureka.EurekaClientAutoConfiguration"})
 public class GracefulShutdownAutoConfiguration {
 
-  @Configuration
-  @ConditionalOnClass(name = "org.springframework.boot.actuate.health.AbstractHealthIndicator")
-  protected static class HealthIndicatorConfiguration {
+    @Configuration
+    @ConditionalOnClass(name = "org.springframework.boot.actuate.health.AbstractHealthIndicator")
+    protected static class HealthIndicatorConfiguration {
 
-    @Bean
-    @ConditionalOnProperty(value = "tw-graceful-shutdown.health-indicator.enabled", matchIfMissing = true)
-    public GracefulShutdownHealthStrategy gracefulShutdownHealthStrategy() {
-      return new GracefulShutdownHealthStrategy();
+        @Bean
+        @ConditionalOnProperty(value = "tw-graceful-shutdown.health-indicator.enabled", matchIfMissing = true)
+        public GracefulShutdownHealthStrategy gracefulShutdownHealthStrategy() {
+            return new GracefulShutdownHealthStrategy();
+        }
+
+        @Bean
+        @ConditionalOnProperty(value = "tw-graceful-shutdown.health-indicator.enabled", matchIfMissing = true)
+        public GracefulShutdownHealthIndicator gracefulShutdownHealthIndicator() {
+            return new GracefulShutdownHealthIndicator();
+        }
+    }
+
+    @Configuration
+    @RequiredArgsConstructor
+    @EnableConfigurationProperties({RequestCountStrategyProperties.class})
+    @ConditionalOnClass(name = "javax.servlet.Filter")
+    protected static class ServletConfiguration {
+
+        private final RequestCountStrategyProperties requestCountStrategyProperties;
+
+        @Bean
+        @ConditionalOnProperty(value = "tw-graceful-shutdown.request-count-strategy.enabled", matchIfMissing = true)
+        public FilterRegistrationBean<RequestCountGracefulShutdownStrategy> requestCountGracefulShutdownStrategyFilter() {
+            FilterRegistrationBean<RequestCountGracefulShutdownStrategy> registrationBean = new FilterRegistrationBean<>();
+            registrationBean.setFilter(requestCountGracefulShutdownStrategy());
+            registrationBean.setOrder(requestCountStrategyProperties.getFilterOrder());
+            return registrationBean;
+        }
+
+        @Bean
+        @ConditionalOnProperty(value = "tw-graceful-shutdown.request-count-strategy.enabled", matchIfMissing = true)
+        public RequestCountGracefulShutdownStrategy requestCountGracefulShutdownStrategy() {
+            return new RequestCountGracefulShutdownStrategy();
+        }
     }
 
     @Bean
-    @ConditionalOnProperty(value = "tw-graceful-shutdown.health-indicator.enabled", matchIfMissing = true)
-    public GracefulShutdownHealthIndicator gracefulShutdownHealthIndicator() {
-      return new GracefulShutdownHealthIndicator();
-    }
-  }
-
-  @Configuration
-  @RequiredArgsConstructor
-  @EnableConfigurationProperties({RequestCountStrategyProperties.class})
-  @ConditionalOnClass(name = "javax.servlet.Filter")
-  protected static class ServletConfiguration {
-
-    private final RequestCountStrategyProperties requestCountStrategyProperties;
-
-    @Bean
-    @ConditionalOnProperty(value = "tw-graceful-shutdown.request-count-strategy.enabled", matchIfMissing = true)
-    public FilterRegistrationBean<RequestCountGracefulShutdownStrategy> requestCountGracefulShutdownStrategyFilter() {
-      FilterRegistrationBean<RequestCountGracefulShutdownStrategy> registrationBean = new FilterRegistrationBean<>();
-      registrationBean.setFilter(requestCountGracefulShutdownStrategy());
-      registrationBean.setOrder(requestCountStrategyProperties.getFilterOrder());
-      return registrationBean;
+    @ConditionalOnProperty(value = "tw-graceful-shutdown.db-scheduler.enabled")
+    public ScheduledTaskShutdownStrategy scheduledTaskShutdownStrategy(final Scheduler scheduler) {
+        return new ScheduledTaskShutdownStrategy(scheduler);
     }
 
     @Bean
-    @ConditionalOnProperty(value = "tw-graceful-shutdown.request-count-strategy.enabled", matchIfMissing = true)
-    public RequestCountGracefulShutdownStrategy requestCountGracefulShutdownStrategy() {
-      return new RequestCountGracefulShutdownStrategy();
+    @ConditionalOnMissingBean
+    public GracefulShutdowner gracefulShutdowner() {
+        return new GracefulShutdowner();
     }
-  }
 
-  @Bean
-  @ConditionalOnProperty(value = "tw-graceful-shutdown.db-scheduler.enabled")
-  public ScheduledTaskShutdownStrategy scheduledTaskShutdownStrategy(final Scheduler scheduler) {
-    return new ScheduledTaskShutdownStrategy(scheduler);
-  }
-
-  @Bean
-  @ConditionalOnMissingBean
-  public GracefulShutdowner gracefulShutdowner() {
-    return new GracefulShutdowner();
-  }
-
-  @Bean
-  @ConditionalOnMissingBean
-  public GracefulShutdownStrategiesRegistry gracefulShutdownStrategiesRegistry() {
-    return new DefaultGracefulShutdownStrategiesRegistry();
-  }
+    @Bean
+    @ConditionalOnMissingBean
+    public GracefulShutdownStrategiesRegistry gracefulShutdownStrategiesRegistry() {
+        return new DefaultGracefulShutdownStrategiesRegistry();
+    }
 
 }

--- a/core/src/main/java/com/transferwise/common/gracefulshutdown/GracefulShutdownAutoConfiguration.java
+++ b/core/src/main/java/com/transferwise/common/gracefulshutdown/GracefulShutdownAutoConfiguration.java
@@ -1,9 +1,7 @@
 package com.transferwise.common.gracefulshutdown;
 
-import com.github.kagkarlsson.scheduler.Scheduler;
 import com.transferwise.common.gracefulshutdown.config.GracefulShutdownProperties;
 import com.transferwise.common.gracefulshutdown.config.RequestCountStrategyProperties;
-import com.transferwise.common.gracefulshutdown.config.ScheduledTaskShutdownStrategy;
 import com.transferwise.common.gracefulshutdown.strategies.GracefulShutdownHealthStrategy;
 import com.transferwise.common.gracefulshutdown.strategies.RequestCountGracefulShutdownStrategy;
 import lombok.RequiredArgsConstructor;

--- a/core/src/main/java/com/transferwise/common/gracefulshutdown/GracefulShutdownAutoConfiguration.java
+++ b/core/src/main/java/com/transferwise/common/gracefulshutdown/GracefulShutdownAutoConfiguration.java
@@ -22,63 +22,63 @@ import org.springframework.context.annotation.Configuration;
 @AutoConfigureAfter(name = {"org.springframework.cloud.netflix.eureka.EurekaClientAutoConfiguration"})
 public class GracefulShutdownAutoConfiguration {
 
-    @Configuration
-    @ConditionalOnClass(name = "org.springframework.boot.actuate.health.AbstractHealthIndicator")
-    protected static class HealthIndicatorConfiguration {
+  @Configuration
+  @ConditionalOnClass(name = "org.springframework.boot.actuate.health.AbstractHealthIndicator")
+  protected static class HealthIndicatorConfiguration {
 
-        @Bean
-        @ConditionalOnProperty(value = "tw-graceful-shutdown.health-indicator.enabled", matchIfMissing = true)
-        public GracefulShutdownHealthStrategy gracefulShutdownHealthStrategy() {
-            return new GracefulShutdownHealthStrategy();
-        }
-
-        @Bean
-        @ConditionalOnProperty(value = "tw-graceful-shutdown.health-indicator.enabled", matchIfMissing = true)
-        public GracefulShutdownHealthIndicator gracefulShutdownHealthIndicator() {
-            return new GracefulShutdownHealthIndicator();
-        }
-    }
-
-    @Configuration
-    @RequiredArgsConstructor
-    @EnableConfigurationProperties({RequestCountStrategyProperties.class})
-    @ConditionalOnClass(name = "javax.servlet.Filter")
-    protected static class ServletConfiguration {
-
-        private final RequestCountStrategyProperties requestCountStrategyProperties;
-
-        @Bean
-        @ConditionalOnProperty(value = "tw-graceful-shutdown.request-count-strategy.enabled", matchIfMissing = true)
-        public FilterRegistrationBean<RequestCountGracefulShutdownStrategy> requestCountGracefulShutdownStrategyFilter() {
-            FilterRegistrationBean<RequestCountGracefulShutdownStrategy> registrationBean = new FilterRegistrationBean<>();
-            registrationBean.setFilter(requestCountGracefulShutdownStrategy());
-            registrationBean.setOrder(requestCountStrategyProperties.getFilterOrder());
-            return registrationBean;
-        }
-
-        @Bean
-        @ConditionalOnProperty(value = "tw-graceful-shutdown.request-count-strategy.enabled", matchIfMissing = true)
-        public RequestCountGracefulShutdownStrategy requestCountGracefulShutdownStrategy() {
-            return new RequestCountGracefulShutdownStrategy();
-        }
+    @Bean
+    @ConditionalOnProperty(value = "tw-graceful-shutdown.health-indicator.enabled", matchIfMissing = true)
+    public GracefulShutdownHealthStrategy gracefulShutdownHealthStrategy() {
+      return new GracefulShutdownHealthStrategy();
     }
 
     @Bean
-    @ConditionalOnProperty(value = "tw-graceful-shutdown.db-scheduler.enabled")
-    public ScheduledTaskShutdownStrategy scheduledTaskShutdownStrategy(final Scheduler scheduler) {
-        return new ScheduledTaskShutdownStrategy(scheduler);
+    @ConditionalOnProperty(value = "tw-graceful-shutdown.health-indicator.enabled", matchIfMissing = true)
+    public GracefulShutdownHealthIndicator gracefulShutdownHealthIndicator() {
+      return new GracefulShutdownHealthIndicator();
+    }
+  }
+
+  @Configuration
+  @RequiredArgsConstructor
+  @EnableConfigurationProperties({RequestCountStrategyProperties.class})
+  @ConditionalOnClass(name = "javax.servlet.Filter")
+  protected static class ServletConfiguration {
+
+    private final RequestCountStrategyProperties requestCountStrategyProperties;
+
+    @Bean
+    @ConditionalOnProperty(value = "tw-graceful-shutdown.request-count-strategy.enabled", matchIfMissing = true)
+    public FilterRegistrationBean<RequestCountGracefulShutdownStrategy> requestCountGracefulShutdownStrategyFilter() {
+      FilterRegistrationBean<RequestCountGracefulShutdownStrategy> registrationBean = new FilterRegistrationBean<>();
+      registrationBean.setFilter(requestCountGracefulShutdownStrategy());
+      registrationBean.setOrder(requestCountStrategyProperties.getFilterOrder());
+      return registrationBean;
     }
 
     @Bean
-    @ConditionalOnMissingBean
-    public GracefulShutdowner gracefulShutdowner() {
-        return new GracefulShutdowner();
+    @ConditionalOnProperty(value = "tw-graceful-shutdown.request-count-strategy.enabled", matchIfMissing = true)
+    public RequestCountGracefulShutdownStrategy requestCountGracefulShutdownStrategy() {
+      return new RequestCountGracefulShutdownStrategy();
     }
+  }
 
-    @Bean
-    @ConditionalOnMissingBean
-    public GracefulShutdownStrategiesRegistry gracefulShutdownStrategiesRegistry() {
-        return new DefaultGracefulShutdownStrategiesRegistry();
-    }
+  @Bean
+  @ConditionalOnProperty(value = "tw-graceful-shutdown.db-scheduler.enabled")
+  public ScheduledTaskShutdownStrategy scheduledTaskShutdownStrategy(final Scheduler scheduler) {
+    return new ScheduledTaskShutdownStrategy(scheduler);
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
+  public GracefulShutdowner gracefulShutdowner() {
+    return new GracefulShutdowner();
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
+  public GracefulShutdownStrategiesRegistry gracefulShutdownStrategiesRegistry() {
+    return new DefaultGracefulShutdownStrategiesRegistry();
+  }
 
 }

--- a/core/src/main/java/com/transferwise/common/gracefulshutdown/config/ScheduledTaskShutdownStrategy.java
+++ b/core/src/main/java/com/transferwise/common/gracefulshutdown/config/ScheduledTaskShutdownStrategy.java
@@ -1,0 +1,4 @@
+package com.transferwise.common.gracefulshutdown.config;
+
+public class ScheduledTaskShutdownStrategy {
+}

--- a/core/src/main/java/com/transferwise/common/gracefulshutdown/config/ScheduledTaskShutdownStrategy.java
+++ b/core/src/main/java/com/transferwise/common/gracefulshutdown/config/ScheduledTaskShutdownStrategy.java
@@ -4,9 +4,15 @@ import com.github.kagkarlsson.scheduler.Scheduler;
 import com.transferwise.common.gracefulshutdown.GracefulShutdownStrategy;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
 
 @RequiredArgsConstructor
 @Slf4j
+@Component
+@ConditionalOnClass(name = "com.github.kagkarlsson.scheduler.Scheduler")
+@ConditionalOnProperty(value = "tw-graceful-shutdown.db-scheduler.enabled", matchIfMissing = true)
 public class ScheduledTaskShutdownStrategy implements GracefulShutdownStrategy {
   private final Scheduler scheduler;
 

--- a/core/src/main/java/com/transferwise/common/gracefulshutdown/config/ScheduledTaskShutdownStrategy.java
+++ b/core/src/main/java/com/transferwise/common/gracefulshutdown/config/ScheduledTaskShutdownStrategy.java
@@ -1,4 +1,23 @@
 package com.transferwise.common.gracefulshutdown.config;
 
-public class ScheduledTaskShutdownStrategy {
+import com.github.kagkarlsson.scheduler.Scheduler;
+import com.transferwise.common.gracefulshutdown.GracefulShutdownStrategy;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RequiredArgsConstructor
+@Slf4j
+public class ScheduledTaskShutdownStrategy implements GracefulShutdownStrategy {
+    private final Scheduler scheduler;
+
+    @Override
+    public void prepareForShutdown() {
+        log.info("Attempting to shutdown scheduler");
+        scheduler.stop();
+    }
+
+    @Override
+    public boolean canShutdown() {
+        return scheduler.getCurrentlyExecuting().isEmpty();
+    }
 }

--- a/core/src/main/java/com/transferwise/common/gracefulshutdown/config/ScheduledTaskShutdownStrategy.java
+++ b/core/src/main/java/com/transferwise/common/gracefulshutdown/config/ScheduledTaskShutdownStrategy.java
@@ -8,16 +8,16 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @Slf4j
 public class ScheduledTaskShutdownStrategy implements GracefulShutdownStrategy {
-    private final Scheduler scheduler;
+  private final Scheduler scheduler;
 
-    @Override
-    public void prepareForShutdown() {
-        log.info("Attempting to shutdown scheduler");
-        scheduler.stop();
-    }
+  @Override
+  public void prepareForShutdown() {
+    log.info("Attempting to shutdown scheduler");
+    scheduler.stop();
+  }
 
-    @Override
-    public boolean canShutdown() {
-        return scheduler.getCurrentlyExecuting().isEmpty();
-    }
+  @Override
+  public boolean canShutdown() {
+    return scheduler.getCurrentlyExecuting().isEmpty();
+  }
 }

--- a/core/src/main/resources/META-INF/spring.factories
+++ b/core/src/main/resources/META-INF/spring.factories
@@ -1,1 +1,1 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=com.transferwise.common.gracefulshutdown.GracefulShutdownAutoConfiguration
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=com.transferwise.common.gracefulshutdown.GracefulShutdownAutoConfiguration,com.transferwise.common.gracefulshutdown.config.ScheduledTaskShutdownStrategy

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=2.3.1
+version=2.4.0


### PR DESCRIPTION
## Context

Adding a strategy to handle graceful shutdown for apps that enable the db-scheduler bean 


## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
