### PR TITLE
Added strategy for graceful shutdown of spring task scheduler beans.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,26 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
+to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [2.5.0] - 2021-08-12
+
+### Changes
+
+* Added strategy for graceful shutdown of spring task scheduler beans. The ones, handling Scheduled annotation, for example.
 
 ## [2.4.0] - 2021-08-12
+
 ### Changes
-* Added strategy for graceful shutdown of db-scheduler beans 
+
+* Added strategy for graceful shutdown of db-scheduler beans
 
 ## [2.3.1] - 2021-08-12
+
 ### Changes
+
 * use `compareAndSet` to avoid `stop` from executing twice in GracefulShutdowner
 
 ## [2.3.0] - 2021-05-28

--- a/build.libraries.gradle
+++ b/build.libraries.gradle
@@ -1,6 +1,7 @@
 ext {
     libraries = [
             // version defined
+            awaitility                      : 'org.awaitility:awaitility:4.2.0',
             dbScheduler                     : 'com.github.kagkarlsson:db-scheduler:11.0',
             dbSchedulerSpringBootStarter    : 'com.github.kagkarlsson:db-scheduler-spring-boot-starter:11.0',
             guava                           : 'com.google.guava:guava:31.1-jre',

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -47,6 +47,7 @@ dependencies {
 
     testImplementation libraries.javaxServletApi
     testImplementation libraries.springBootStarterTest
+    testImplementation libraries.awaitility
     
     testRuntimeOnly libraries.dbSchedulerSpringBootStarter
     testRuntimeOnly libraries.springBootStarterJdbc

--- a/core/src/main/java/com/transferwise/common/gracefulshutdown/GracefulShutdowner.java
+++ b/core/src/main/java/com/transferwise/common/gracefulshutdown/GracefulShutdowner.java
@@ -96,7 +96,7 @@ public class GracefulShutdowner implements ApplicationListener<ApplicationReadyE
             break;
           }
           log.info("Not shutting down yet, {} strategies have red light. Waiting for {} ms for next check.",
-                  redLightStrategies, properties.getStrategiesCheckIntervalTimeMs());
+              redLightStrategies, properties.getStrategiesCheckIntervalTimeMs());
           Thread.sleep(properties.getStrategiesCheckIntervalTimeMs());
         }
 

--- a/core/src/main/java/com/transferwise/common/gracefulshutdown/strategies/TaskSchedulersGracefulShutdownStrategy.java
+++ b/core/src/main/java/com/transferwise/common/gracefulshutdown/strategies/TaskSchedulersGracefulShutdownStrategy.java
@@ -20,11 +20,12 @@ public class TaskSchedulersGracefulShutdownStrategy implements GracefulShutdownS
 
   @Override
   public void prepareForShutdown() {
-    var taskSchedulers = applicationContext.getBeansOfType(TaskScheduler.class).values();
-
     var executors = Executors.newFixedThreadPool(10);
+
+    var taskSchedulers = applicationContext.getBeansOfType(TaskScheduler.class).values();
+    inProgressShutdowns.getAndSet(taskSchedulers.size());
+
     for (var taskScheduler : taskSchedulers) {
-      inProgressShutdowns.incrementAndGet();
       executors.submit(() -> {
         try {
           if (taskScheduler instanceof ThreadPoolTaskScheduler) {

--- a/core/src/main/java/com/transferwise/common/gracefulshutdown/strategies/TaskSchedulersGracefulShutdownStrategy.java
+++ b/core/src/main/java/com/transferwise/common/gracefulshutdown/strategies/TaskSchedulersGracefulShutdownStrategy.java
@@ -1,0 +1,76 @@
+package com.transferwise.common.gracefulshutdown.strategies;
+
+import com.transferwise.common.gracefulshutdown.GracefulShutdownStrategy;
+import java.util.concurrent.Executors;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.ConcurrentTaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+@Slf4j
+public class TaskSchedulersGracefulShutdownStrategy implements GracefulShutdownStrategy {
+
+  @Autowired
+  private ApplicationContext applicationContext;
+
+  private volatile boolean canShutDown = true;
+
+  @Override
+  public void prepareForShutdown() {
+    var taskSchedulers = applicationContext.getBeansOfType(TaskScheduler.class).values();
+
+    canShutDown = false;
+    var executors = Executors.newFixedThreadPool(10);
+    executors.submit(() -> {
+      try {
+        for (var taskScheduler : taskSchedulers) {
+          if (taskScheduler instanceof ThreadPoolTaskScheduler) {
+            log.info("Shutting down thread pool task scheduler '{}'.", taskScheduler);
+            var threadPoolTaskScheduler = (ThreadPoolTaskScheduler) taskScheduler;
+            threadPoolTaskScheduler.setWaitForTasksToCompleteOnShutdown(true);
+            threadPoolTaskScheduler.shutdown();
+          } else if (taskScheduler instanceof ConcurrentTaskScheduler) {
+            log.info("Shutting down thread pool task scheduler '{}'.", taskScheduler);
+            var concurrentTaskScheduler = (ConcurrentTaskScheduler) taskScheduler;
+            var executor = concurrentTaskScheduler.getConcurrentExecutor();
+
+            try {
+              var shutdownMethod = executor.getClass().getMethod("shutdown");
+              shutdownMethod.invoke(executor);
+            } catch (NoSuchMethodException ignored) {
+              // ignored
+            } catch (Throwable t) {
+              log.error("Shutting down concurrent task scheduler executor failed.", t);
+            }
+          } else {
+            boolean shutdownCalled = false;
+            try {
+              var shutdownMethod = taskScheduler.getClass().getMethod("shutdown");
+              log.info("Shutting down unknown task scheduler '{}' using it's 'shutdown()' method.", taskScheduler);
+              shutdownMethod.invoke(taskScheduler);
+              shutdownCalled = true;
+            } catch (NoSuchMethodException ignored) {
+              // ignored
+            } catch (Throwable t) {
+              log.error("Shutting down concurrent task scheduler executor failed.", t);
+            }
+            if (!shutdownCalled) {
+              log.warn("Found a task scheduler '{}', but do not know how to shut it down. Please contact SRE team.", taskScheduler);
+            }
+          }
+        }
+      } catch (Throwable t) {
+        log.error("Stopping a task scheduler failed.", t);
+      } finally {
+        canShutDown = true;
+      }
+    });
+  }
+
+  @Override
+  public boolean canShutdown() {
+    return canShutDown;
+  }
+}

--- a/core/src/main/java/com/transferwise/common/gracefulshutdown/strategies/TaskSchedulersGracefulShutdownStrategy.java
+++ b/core/src/main/java/com/transferwise/common/gracefulshutdown/strategies/TaskSchedulersGracefulShutdownStrategy.java
@@ -32,7 +32,7 @@ public class TaskSchedulersGracefulShutdownStrategy implements GracefulShutdownS
             threadPoolTaskScheduler.setWaitForTasksToCompleteOnShutdown(true);
             threadPoolTaskScheduler.shutdown();
           } else if (taskScheduler instanceof ConcurrentTaskScheduler) {
-            log.info("Shutting down thread pool task scheduler '{}'.", taskScheduler);
+            log.info("Shutting down concurrent task scheduler '{}'.", taskScheduler);
             var concurrentTaskScheduler = (ConcurrentTaskScheduler) taskScheduler;
             var executor = concurrentTaskScheduler.getConcurrentExecutor();
 
@@ -45,19 +45,14 @@ public class TaskSchedulersGracefulShutdownStrategy implements GracefulShutdownS
               log.error("Shutting down concurrent task scheduler executor failed.", t);
             }
           } else {
-            boolean shutdownCalled = false;
             try {
               var shutdownMethod = taskScheduler.getClass().getMethod("shutdown");
               log.info("Shutting down unknown task scheduler '{}' using it's 'shutdown()' method.", taskScheduler);
               shutdownMethod.invoke(taskScheduler);
-              shutdownCalled = true;
             } catch (NoSuchMethodException ignored) {
-              // ignored
+              log.warn("Found a task scheduler '{}', but do not know how to shut it down. Please contact SRE team.", taskScheduler);
             } catch (Throwable t) {
               log.error("Shutting down concurrent task scheduler executor failed.", t);
-            }
-            if (!shutdownCalled) {
-              log.warn("Found a task scheduler '{}', but do not know how to shut it down. Please contact SRE team.", taskScheduler);
             }
           }
         }

--- a/core/src/test/java/com/transferwise/common/gracefulshutdown/GracefulShutdownerIntTest.java
+++ b/core/src/test/java/com/transferwise/common/gracefulshutdown/GracefulShutdownerIntTest.java
@@ -5,7 +5,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.transferwise.common.gracefulshutdown.strategies.GracefulShutdownHealthStrategy;
 import com.transferwise.common.gracefulshutdown.strategies.KagkarlssonDbScheduledTaskShutdownStrategy;
 import com.transferwise.common.gracefulshutdown.strategies.RequestCountGracefulShutdownStrategy;
+import com.transferwise.common.gracefulshutdown.strategies.TaskSchedulersGracefulShutdownStrategy;
 import com.transferwise.common.gracefulshutdown.test.TestApplication;
+import lombok.SneakyThrows;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.health.Status;
@@ -29,18 +32,34 @@ class GracefulShutdownerIntTest {
   private GracefulShutdownStrategiesRegistry gracefulShutdownStrategiesRegistry;
   @Autowired
   private KagkarlssonDbScheduledTaskShutdownStrategy kagkarlssonDbScheduledTaskShutdownStrategy;
+  @Autowired
+  private TaskSchedulersGracefulShutdownStrategy taskSchedulersGracefulShutdownStrategy;
+  @Autowired
+  private TestApplication testApplication;
 
   @Test
+  @SneakyThrows
   void testThatItGenerallyWorks() {
+    final var schedulerCounterValue = testApplication.schedulerCounter.get();
     assertThat(gracefulShutdowner.isRunning()).isTrue();
 
     assertThat(gracefulShutdownStrategiesRegistry.getStrategies()).contains(healthStrategy);
     assertThat(gracefulShutdownStrategiesRegistry.getStrategies()).contains(requestCountGracefulShutdownStrategy);
     assertThat(gracefulShutdownStrategiesRegistry.getStrategies()).contains(kagkarlssonDbScheduledTaskShutdownStrategy);
+    assertThat(gracefulShutdownStrategiesRegistry.getStrategies()).contains(kagkarlssonDbScheduledTaskShutdownStrategy);
+    assertThat(gracefulShutdownStrategiesRegistry.getStrategies()).contains(taskSchedulersGracefulShutdownStrategy);
 
     assertThat(healthIndicator.health().getStatus()).isEqualTo(Status.UP);
 
+    Awaitility.await().until(() -> testApplication.schedulerCounter.get() > schedulerCounterValue);
+
     gracefulShutdowner.stop();
+
+    final var newSchedulerCounterValue = testApplication.schedulerCounter.get();
+
+    // No idea, how to make it without sleep. We want to check if the scheduling stopped.
+    Thread.sleep(50);
+    assertThat(testApplication.schedulerCounter.get()).isEqualTo(newSchedulerCounterValue);
 
     assertThat(gracefulShutdowner.isRunning()).isFalse();
     assertThat(healthIndicator.health().getStatus()).isEqualTo(Status.DOWN);

--- a/core/src/test/java/com/transferwise/common/gracefulshutdown/test/TestApplication.java
+++ b/core/src/test/java/com/transferwise/common/gracefulshutdown/test/TestApplication.java
@@ -1,8 +1,19 @@
 package com.transferwise.common.gracefulshutdown.test;
 
+import java.util.concurrent.atomic.AtomicLong;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
 
 @SpringBootApplication
+@EnableScheduling
 public class TestApplication {
+
+  public AtomicLong schedulerCounter = new AtomicLong();
+
+  @Scheduled(fixedDelay = 5)
+  public void doSomethingFrequently() {
+    schedulerCounter.incrementAndGet();
+  }
 
 }

--- a/core/src/test/resources/application.yml
+++ b/core/src/test/resources/application.yml
@@ -3,3 +3,8 @@ spring:
     username: sa
     password: password
     url: jdbc:h2:mem:testdb
+
+db-scheduler:
+  # Allow Flyway to run first.
+  delay-startup-until-context-ready: true
+  

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=2.4.0
+version=2.5.0


### PR DESCRIPTION
## Context

Added strategy for graceful shutdown of spring task scheduler beans. 
The ones, handling Scheduled annotation, for example.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
