### PR TITLE
Supporting Spring scheduling graceful shutdown for more exotic configurations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.6.0] - 2022-05-03
+
+### Changes
+
+* Supporting Spring scheduling graceful shutdown for more exotic configurations.
+
 ## [2.5.0] - 2021-08-12
 
 ### Changes

--- a/build.publishing.gradle
+++ b/build.publishing.gradle
@@ -68,8 +68,8 @@ publishing {
         maven {
             url System.getenv("MAVEN_URL")
             credentials {
-                username = System.getenv("MAVEN_USER")
-                password = System.getenv("MAVEN_PASSWORD")
+                username = System.getenv("MAVEN_USER") ?: artifactoryUser
+                password = System.getenv("MAVEN_PASSWORD") ?: artifactoryPassword
             }
         }
     }

--- a/core/src/main/java/com/transferwise/common/gracefulshutdown/GracefulShutdownAutoConfiguration.java
+++ b/core/src/main/java/com/transferwise/common/gracefulshutdown/GracefulShutdownAutoConfiguration.java
@@ -17,6 +17,8 @@ import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.scheduling.annotation.SchedulingConfigurer;
 
 @Configuration
 @ConditionalOnProperty(value = "tw-graceful-shutdown.enable", matchIfMissing = true)
@@ -85,6 +87,25 @@ public class GracefulShutdownAutoConfiguration {
     @Bean
     public TaskSchedulersGracefulShutdownStrategy taskSchedulersGracefulShutdownStrategy() {
       return new TaskSchedulersGracefulShutdownStrategy();
+    }
+  }
+
+  @Configuration
+  @ConditionalOnMissingBean(type = "org.springframework.scheduling.TaskScheduler")
+  @ConditionalOnBean(type = {"org.springframework.scheduling.annotation.ScheduledAnnotationBeanPostProcessor",
+      "org.springframework.scheduling.annotation.SchedulingConfigurer"})
+  @ConditionalOnProperty(value = "tw-graceful-shutdown.spring-task-scheduler.enabled", matchIfMissing = true)
+  protected static class SpringTaskSchedulerAlternativeConfiguration {
+
+    @Bean
+    public TaskSchedulersGracefulShutdownStrategy taskSchedulersGracefulShutdownStrategy() {
+      return new TaskSchedulersGracefulShutdownStrategy();
+    }
+
+    @Bean
+    @Order()
+    public SchedulingConfigurer twGsSchedulingConfigurer(TaskSchedulersGracefulShutdownStrategy taskSchedulersGracefulShutdownStrategy) {
+      return taskRegistrar -> taskSchedulersGracefulShutdownStrategy.addTaskScheduler(taskRegistrar.getScheduler());
     }
   }
 

--- a/core/src/main/java/com/transferwise/common/gracefulshutdown/GracefulShutdownAutoConfiguration.java
+++ b/core/src/main/java/com/transferwise/common/gracefulshutdown/GracefulShutdownAutoConfiguration.java
@@ -103,7 +103,7 @@ public class GracefulShutdownAutoConfiguration {
     }
 
     @Bean
-    @Order()
+    @Order
     public SchedulingConfigurer twGsSchedulingConfigurer(TaskSchedulersGracefulShutdownStrategy taskSchedulersGracefulShutdownStrategy) {
       return taskRegistrar -> taskSchedulersGracefulShutdownStrategy.addTaskScheduler(taskRegistrar.getScheduler());
     }

--- a/core/src/test/java/com/transferwise/common/gracefulshutdown/test/TestBApplication.java
+++ b/core/src/test/java/com/transferwise/common/gracefulshutdown/test/TestBApplication.java
@@ -1,0 +1,18 @@
+package com.transferwise.common.gracefulshutdown.test;
+
+import java.util.concurrent.Executors;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.SchedulingConfigurer;
+
+// More customized scheduling is set up.
+@SpringBootApplication
+@EnableScheduling
+public class TestBApplication {
+  
+  @Bean
+  public SchedulingConfigurer mySchedulingConfigurer() {
+    return taskRegistrar -> taskRegistrar.setScheduler(Executors.newScheduledThreadPool(2));
+  }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=2.5.0
+version=2.6.0


### PR DESCRIPTION
## Context

Supporting Spring scheduling graceful shutdown for more exotic configurations.

Sometimes a TaskScheduler bean is not present and it gets registered using the TaskRegister class. We add support for this case as well.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
