### PR TITLE
Wrong counter handling prevented Scheduled Tasks strategy to announce that shutdown can continue.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.7.0] - 2022-05-03
+
+### Fixes
+
+* Wrong counter handling prevented Scheduled Tasks strategy to announce that shutdown can continue. Basically in some scenarios the counter got a
+  negative value failing ==0 check at the end.
+
 ## [2.6.0] - 2022-05-03
 
 ### Changes

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -25,6 +25,10 @@ task test2(type: Test) {
     classpath = sourceSets.test2.runtimeClasspath
 }
 
+tasks.findByName("processTest2Resources").configure {
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
+}
+
 test2 {
     useJUnitPlatform()
 }

--- a/core/src/main/java/com/transferwise/common/gracefulshutdown/strategies/TaskSchedulersGracefulShutdownStrategy.java
+++ b/core/src/main/java/com/transferwise/common/gracefulshutdown/strategies/TaskSchedulersGracefulShutdownStrategy.java
@@ -41,9 +41,10 @@ public class TaskSchedulersGracefulShutdownStrategy implements GracefulShutdownS
             log.info("Shutting down thread pool task scheduler '{}'.", taskScheduler);
             var threadPoolTaskScheduler = (ThreadPoolTaskScheduler) taskScheduler;
 
-            threadPoolTaskScheduler.getScheduledThreadPoolExecutor().setExecuteExistingDelayedTasksAfterShutdownPolicy(false);
-            threadPoolTaskScheduler.getScheduledThreadPoolExecutor().setContinueExistingPeriodicTasksAfterShutdownPolicy(false);
-            threadPoolTaskScheduler.getScheduledThreadPoolExecutor().getQueue().clear();
+            var scheduledThreadPoolExecutor = threadPoolTaskScheduler.getScheduledThreadPoolExecutor();
+            scheduledThreadPoolExecutor.setExecuteExistingDelayedTasksAfterShutdownPolicy(false);
+            scheduledThreadPoolExecutor.setContinueExistingPeriodicTasksAfterShutdownPolicy(false);
+            scheduledThreadPoolExecutor.getQueue().clear();
             threadPoolTaskScheduler.setWaitForTasksToCompleteOnShutdown(true);
             threadPoolTaskScheduler.shutdown();
           } else if (taskScheduler instanceof ConcurrentTaskScheduler) {
@@ -52,9 +53,11 @@ public class TaskSchedulersGracefulShutdownStrategy implements GracefulShutdownS
             var executor = concurrentTaskScheduler.getConcurrentExecutor();
 
             if (executor instanceof ScheduledThreadPoolExecutor) {
-              ((ScheduledThreadPoolExecutor) executor).setContinueExistingPeriodicTasksAfterShutdownPolicy(false);
-              ((ScheduledThreadPoolExecutor) executor).setExecuteExistingDelayedTasksAfterShutdownPolicy(false);
-              ((ScheduledThreadPoolExecutor) executor).shutdown();
+              var scheduledThreadPoolExecutor = (ScheduledThreadPoolExecutor) executor;
+              scheduledThreadPoolExecutor.setContinueExistingPeriodicTasksAfterShutdownPolicy(false);
+              scheduledThreadPoolExecutor.setExecuteExistingDelayedTasksAfterShutdownPolicy(false);
+              scheduledThreadPoolExecutor.getQueue().clear();
+              scheduledThreadPoolExecutor.shutdown();
             } else {
               try {
                 var shutdownMethod = executor.getClass().getMethod("shutdown");

--- a/core/src/test/java/com/transferwise/common/gracefulshutdown/AlternativeSchedulingShutdownerIntTest.java
+++ b/core/src/test/java/com/transferwise/common/gracefulshutdown/AlternativeSchedulingShutdownerIntTest.java
@@ -13,8 +13,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
 @ActiveProfiles({"test"})
-@SpringBootTest(classes = {TestBApplication.class},
-    properties = {"tw-graceful-shutdown.clientsReactionTimeMs=1", "tw-graceful-shutdown.shutdownTimeoutMs=1"})
+@SpringBootTest(classes = {TestBApplication.class})
 class AlternativeSchedulingShutdownerIntTest {
 
   @Autowired

--- a/core/src/test/java/com/transferwise/common/gracefulshutdown/GracefulShutdownerIntTest.java
+++ b/core/src/test/java/com/transferwise/common/gracefulshutdown/GracefulShutdownerIntTest.java
@@ -16,8 +16,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
 @ActiveProfiles({"test"})
-@SpringBootTest(classes = {TestApplication.class},
-    properties = {"tw-graceful-shutdown.clientsReactionTimeMs=1", "tw-graceful-shutdown.shutdownTimeoutMs=1"})
+@SpringBootTest(classes = {TestApplication.class})
 class GracefulShutdownerIntTest {
 
   @Autowired

--- a/core/src/test/java/com/transferwise/common/gracefulshutdown/StrategyExecutionOrderIntTest.java
+++ b/core/src/test/java/com/transferwise/common/gracefulshutdown/StrategyExecutionOrderIntTest.java
@@ -11,8 +11,7 @@ import org.springframework.test.context.ActiveProfiles;
 
 // Force a separate ApplicationContext, because we will close this one.
 @ActiveProfiles({"test", "shutdown"})
-@SpringBootTest(classes = {TestApplication.class},
-    properties = {"tw-graceful-shutdown.clientsReactionTimeMs=1", "tw-graceful-shutdown.shutdownTimeoutMs=1"})
+@SpringBootTest(classes = {TestApplication.class})
 public class StrategyExecutionOrderIntTest {
 
   @Autowired

--- a/core/src/test/resources/application.yml
+++ b/core/src/test/resources/application.yml
@@ -8,3 +8,7 @@ db-scheduler:
   # Allow Flyway to run first.
   delay-startup-until-context-ready: true
   
+tw-graceful-shutdown:
+  shutdownTimeoutMs: 15000
+  clientsReactionTimeMs: 1
+  strategiesCheckIntervalTimeMs: 500

--- a/core/src/test2/java/com/transferwise/common/gracefulshutdown/PlainGracefulShutdownerIntTest.java
+++ b/core/src/test2/java/com/transferwise/common/gracefulshutdown/PlainGracefulShutdownerIntTest.java
@@ -11,8 +11,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
 @ActiveProfiles({"test"})
-@SpringBootTest(classes = {TestApplication.class},
-    properties = {"tw-graceful-shutdown.clientsReactionTimeMs=1", "tw-graceful-shutdown.shutdownTimeoutMs=1"})
+@SpringBootTest(classes = {TestApplication.class})
 class PlainGracefulShutdownerIntTest {
 
   @Autowired
@@ -28,12 +27,16 @@ class PlainGracefulShutdownerIntTest {
   void testThatItGenerallyWorks() {
     assertThat(gracefulShutdowner.isRunning()).isTrue();
 
-    assertThat(gracefulShutdownStrategiesRegistry.getStrategies().size()).isEqualTo(1);
+    assertThat(gracefulShutdownStrategiesRegistry.getStrategies().size()).isEqualTo(2);
     assertThat(gracefulShutdownStrategiesRegistry.getStrategies()).contains(healthStrategy);
 
     assertThat(healthIndicator.health().getStatus()).isEqualTo(Status.UP);
 
+    long stopStartTimeMs = System.currentTimeMillis();
     gracefulShutdowner.stop();
+    long stopEndTimeMs = System.currentTimeMillis();
+
+    assertThat(stopEndTimeMs - stopStartTimeMs).as("No strategy is blocking").isLessThan(5_000);
 
     assertThat(gracefulShutdowner.isRunning()).isFalse();
     assertThat(healthIndicator.health().getStatus()).isEqualTo(Status.DOWN);

--- a/core/src/test2/java/com/transferwise/common/gracefulshutdown/test/TestApplication.java
+++ b/core/src/test2/java/com/transferwise/common/gracefulshutdown/test/TestApplication.java
@@ -1,8 +1,16 @@
 package com.transferwise.common.gracefulshutdown.test;
 
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
 
 @SpringBootApplication
+@EnableScheduling
 public class TestApplication {
+
+  @Scheduled(fixedDelay = 5)
+  public void doSomethingFrequently() {
+    // something
+  }
 
 }

--- a/core/src/test2/resources/application.yml
+++ b/core/src/test2/resources/application.yml
@@ -1,0 +1,4 @@
+tw-graceful-shutdown:
+  shutdownTimeoutMs: 15000
+  clientsReactionTimeMs: 1
+  strategiesCheckIntervalTimeMs: 500

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=2.6.0
+version=2.7.0


### PR DESCRIPTION
## Context

* Wrong counter handling prevented Scheduled Tasks strategy to announce that shutdown can continue.
  Basically in some scenarios the counter got a negative value failing ==0 check at the end.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
