### PR TITLE
fix: executor shutdown on private class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.8.1] - 2022-12-27
+
+### Changes
+
+* Fix IllegalAccessException on shutting down Executors defined as private class
+
+
 ## [2.8.0] - 2022-11-10
 
 ### Changes

--- a/core/src/main/java/com/transferwise/common/gracefulshutdown/strategies/TaskSchedulersGracefulShutdownStrategy.java
+++ b/core/src/main/java/com/transferwise/common/gracefulshutdown/strategies/TaskSchedulersGracefulShutdownStrategy.java
@@ -4,6 +4,7 @@ import com.transferwise.common.gracefulshutdown.GracefulShutdownStrategy;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -58,6 +59,8 @@ public class TaskSchedulersGracefulShutdownStrategy implements GracefulShutdownS
               scheduledThreadPoolExecutor.setExecuteExistingDelayedTasksAfterShutdownPolicy(false);
               scheduledThreadPoolExecutor.getQueue().clear();
               scheduledThreadPoolExecutor.shutdown();
+            } else if (executor instanceof ExecutorService) {
+              ((ExecutorService) executor).shutdown();
             } else {
               try {
                 var shutdownMethod = executor.getClass().getMethod("shutdown");

--- a/core/src/test/java/com/transferwise/common/gracefulshutdown/strategies/TaskSchedulersGracefulShutdownStrategyTest.java
+++ b/core/src/test/java/com/transferwise/common/gracefulshutdown/strategies/TaskSchedulersGracefulShutdownStrategyTest.java
@@ -1,32 +1,31 @@
 package com.transferwise.common.gracefulshutdown.strategies;
 
+import java.lang.reflect.Field;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.support.StaticApplicationContext;
 import org.springframework.scheduling.concurrent.ConcurrentTaskScheduler;
 
-import java.lang.reflect.Field;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executors;
-
 class TaskSchedulersGracefulShutdownStrategyTest {
 
-    @Test
-    public void shutdown_invoked_on_private_classes() throws NoSuchFieldException, IllegalAccessException, ExecutionException, InterruptedException {
-        // GIVEN
-        var executor = Executors.newSingleThreadScheduledExecutor();
-        var scheduler = new ConcurrentTaskScheduler(executor);
-        var strategy = new TaskSchedulersGracefulShutdownStrategy();
-        strategy.addTaskScheduler(scheduler);
+  @Test
+  public void shutdown_invoked_on_private_classes() throws NoSuchFieldException, IllegalAccessException, ExecutionException, InterruptedException {
+    // GIVEN
+    var executor = Executors.newSingleThreadScheduledExecutor();
+    var scheduler = new ConcurrentTaskScheduler(executor);
+    var strategy = new TaskSchedulersGracefulShutdownStrategy();
+    strategy.addTaskScheduler(scheduler);
 
-        Field field = TaskSchedulersGracefulShutdownStrategy.class.getDeclaredField("applicationContext");
-        field.setAccessible(true);
-        field.set(strategy, new StaticApplicationContext());
+    Field field = TaskSchedulersGracefulShutdownStrategy.class.getDeclaredField("applicationContext");
+    field.setAccessible(true);
+    field.set(strategy, new StaticApplicationContext());
 
-        // WHEN
-        strategy.prepareForShutdown();
+    // WHEN
+    strategy.prepareForShutdown();
 
-        // THEN
-        Awaitility.await().until(executor::isShutdown);
-    }
+    // THEN
+    Awaitility.await().until(executor::isShutdown);
+  }
 }

--- a/core/src/test/java/com/transferwise/common/gracefulshutdown/strategies/TaskSchedulersGracefulShutdownStrategyTest.java
+++ b/core/src/test/java/com/transferwise/common/gracefulshutdown/strategies/TaskSchedulersGracefulShutdownStrategyTest.java
@@ -1,0 +1,32 @@
+package com.transferwise.common.gracefulshutdown.strategies;
+
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.support.StaticApplicationContext;
+import org.springframework.scheduling.concurrent.ConcurrentTaskScheduler;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+
+class TaskSchedulersGracefulShutdownStrategyTest {
+
+    @Test
+    public void shutdown_invoked_on_private_classes() throws NoSuchFieldException, IllegalAccessException, ExecutionException, InterruptedException {
+        // GIVEN
+        var executor = Executors.newSingleThreadScheduledExecutor();
+        var scheduler = new ConcurrentTaskScheduler(executor);
+        var strategy = new TaskSchedulersGracefulShutdownStrategy();
+        strategy.addTaskScheduler(scheduler);
+
+        Field field = TaskSchedulersGracefulShutdownStrategy.class.getDeclaredField("applicationContext");
+        field.setAccessible(true);
+        field.set(strategy, new StaticApplicationContext());
+
+        // WHEN
+        strategy.prepareForShutdown();
+
+        // THEN
+        Awaitility.await().until(executor::isShutdown);
+    }
+}

--- a/core/src/test/java/com/transferwise/common/gracefulshutdown/strategies/TaskSchedulersGracefulShutdownStrategyTest.java
+++ b/core/src/test/java/com/transferwise/common/gracefulshutdown/strategies/TaskSchedulersGracefulShutdownStrategyTest.java
@@ -1,7 +1,6 @@
 package com.transferwise.common.gracefulshutdown.strategies;
 
 import java.lang.reflect.Field;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
@@ -11,7 +10,7 @@ import org.springframework.scheduling.concurrent.ConcurrentTaskScheduler;
 class TaskSchedulersGracefulShutdownStrategyTest {
 
   @Test
-  public void shutdown_invoked_on_private_classes() throws NoSuchFieldException, IllegalAccessException, ExecutionException, InterruptedException {
+  public void shutdown_invoked_on_private_classes() throws NoSuchFieldException, IllegalAccessException {
     // GIVEN
     var executor = Executors.newSingleThreadScheduledExecutor();
     var scheduler = new ConcurrentTaskScheduler(executor);

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=2.8.0
+version=2.8.1


### PR DESCRIPTION
## Context

Using `executor.getClass().getMethod("shutdown").invoke(executor)` throws an `IllegalAccessException` when `executor` is an instance of a private class.

Which is not uncommon, eg.: `Executors$DelegatedExecutorService` in Azul 15.

So in these cases, we can just cast to `ExecutorService` and call the method directly.

JIRA: FRAUDENG-1830

## Checklist
- [X] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
