### PR TITLE
Implement ExecutorService shutdown strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.8.2] - 2023-01-19
+
+### Changes
+
+* Added strategy for graceful shutdown of ExecutorServices
+
+
 ## [2.8.1] - 2022-12-27
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.8.2] - 2023-01-19
+## [2.9.0] - 2023-01-19
 
 ### Changes
 

--- a/build.libraries.gradle
+++ b/build.libraries.gradle
@@ -22,5 +22,6 @@ ext {
             springBootStarterTest           : 'org.springframework.boot:spring-boot-starter-test',
             springContext                   : 'org.springframework:spring-context',
             springWeb                       : 'org.springframework:spring-web',
+            reactorCore                     : 'io.projectreactor:reactor-core',
     ]
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -43,6 +43,7 @@ dependencies {
     implementation libraries.springBootActuator
     annotationProcessor libraries.springBootConfigurationProcessor
     implementation libraries.springWeb
+    implementation libraries.reactorCore
     implementation libraries.guava
 
     compileOnly libraries.dbSchedulerSpringBootStarter
@@ -53,7 +54,7 @@ dependencies {
     testImplementation libraries.javaxServletApi
     testImplementation libraries.springBootStarterTest
     testImplementation libraries.awaitility
-    
+
     testRuntimeOnly libraries.dbSchedulerSpringBootStarter
     testRuntimeOnly libraries.springBootStarterJdbc
     testRuntimeOnly libraries.h2
@@ -62,4 +63,5 @@ dependencies {
     testCompileOnly libraries.spotbugsAnnotations
 
     test2Implementation libraries.springBootStarterTest
+    test2Implementation libraries.awaitility
 }

--- a/core/src/main/java/com/transferwise/common/gracefulshutdown/GracefulShutdownAutoConfiguration.java
+++ b/core/src/main/java/com/transferwise/common/gracefulshutdown/GracefulShutdownAutoConfiguration.java
@@ -88,8 +88,8 @@ public class GracefulShutdownAutoConfiguration {
   protected static class SpringTaskSchedulerConfiguration {
 
     @Bean
-    public TaskSchedulersGracefulShutdownStrategy taskSchedulersGracefulShutdownStrategy() {
-      return new TaskSchedulersGracefulShutdownStrategy();
+    public TaskSchedulersGracefulShutdownStrategy taskSchedulersGracefulShutdownStrategy(@Autowired ApplicationContext applicationContext) {
+      return new TaskSchedulersGracefulShutdownStrategy(applicationContext);
     }
   }
 
@@ -101,8 +101,8 @@ public class GracefulShutdownAutoConfiguration {
   protected static class SpringTaskSchedulerAlternativeConfiguration {
 
     @Bean
-    public TaskSchedulersGracefulShutdownStrategy taskSchedulersGracefulShutdownStrategy() {
-      return new TaskSchedulersGracefulShutdownStrategy();
+    public TaskSchedulersGracefulShutdownStrategy taskSchedulersGracefulShutdownStrategy(@Autowired ApplicationContext applicationContext) {
+      return new TaskSchedulersGracefulShutdownStrategy(applicationContext);
     }
 
     @Bean

--- a/core/src/main/java/com/transferwise/common/gracefulshutdown/GracefulShutdownAutoConfiguration.java
+++ b/core/src/main/java/com/transferwise/common/gracefulshutdown/GracefulShutdownAutoConfiguration.java
@@ -2,11 +2,13 @@ package com.transferwise.common.gracefulshutdown;
 
 import com.transferwise.common.gracefulshutdown.config.GracefulShutdownProperties;
 import com.transferwise.common.gracefulshutdown.config.RequestCountStrategyProperties;
+import com.transferwise.common.gracefulshutdown.strategies.ExecutorServiceGracefulShutdownStrategy;
 import com.transferwise.common.gracefulshutdown.strategies.GracefulShutdownHealthStrategy;
 import com.transferwise.common.gracefulshutdown.strategies.KagkarlssonDbScheduledTaskShutdownStrategy;
 import com.transferwise.common.gracefulshutdown.strategies.RequestCountGracefulShutdownStrategy;
 import com.transferwise.common.gracefulshutdown.strategies.TaskSchedulersGracefulShutdownStrategy;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfigureOrder;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -14,6 +16,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
@@ -106,6 +109,20 @@ public class GracefulShutdownAutoConfiguration {
     @Order
     public SchedulingConfigurer twGsSchedulingConfigurer(TaskSchedulersGracefulShutdownStrategy taskSchedulersGracefulShutdownStrategy) {
       return taskRegistrar -> taskSchedulersGracefulShutdownStrategy.addTaskScheduler(taskRegistrar.getScheduler());
+    }
+  }
+
+  @Configuration
+  @ConditionalOnClass(name = "java.util.concurrent.ExecutorService")
+  @ConditionalOnProperty(value = "tw-graceful-shutdown.executor-service.enabled", matchIfMissing = true)
+  @ConditionalOnBean(java.util.concurrent.ExecutorService.class)
+  protected static class ExecutorServiceGracefulShutdownStrategyConfiguration {
+    @Bean
+    public ExecutorServiceGracefulShutdownStrategy executorServiceGracefulShutdownStrategy(
+            @Autowired ApplicationContext applicationContext,
+            @Autowired GracefulShutdownProperties gracefulShutdownProperties
+    ) {
+      return new ExecutorServiceGracefulShutdownStrategy(applicationContext, gracefulShutdownProperties);
     }
   }
 

--- a/core/src/main/java/com/transferwise/common/gracefulshutdown/GracefulShutdowner.java
+++ b/core/src/main/java/com/transferwise/common/gracefulshutdown/GracefulShutdowner.java
@@ -82,7 +82,11 @@ public class GracefulShutdowner implements ApplicationListener<ApplicationReadyE
 
         long start = System.currentTimeMillis();
         List<GracefulShutdownStrategy> redLightStrategies = new ArrayList<>(strategies);
-        while (System.currentTimeMillis() - start < properties.getShutdownTimeoutMs()) {
+
+        // slightly increase timeout here
+        // now strategies could safely try to shut down within GracefulShutdownProperties.getShutdownTimeoutMs()
+        int safeShutdownTimeoutMs = properties.getShutdownTimeoutMs() + 500;
+        while (System.currentTimeMillis() - start < safeShutdownTimeoutMs) {
           redLightStrategies = redLightStrategies.stream().filter((s) -> {
             try {
               return !s.canShutdown();

--- a/core/src/main/java/com/transferwise/common/gracefulshutdown/GracefulShutdowner.java
+++ b/core/src/main/java/com/transferwise/common/gracefulshutdown/GracefulShutdowner.java
@@ -85,7 +85,7 @@ public class GracefulShutdowner implements ApplicationListener<ApplicationReadyE
 
         // increase timeout here
         // now strategies could safely try to shut down within GracefulShutdownProperties.getStrategyShutdownTimeout()
-        int safeShutdownTimeoutMs = properties.getStrategyShutdownTimeout() + 5000;
+        int safeShutdownTimeoutMs = properties.getShutdownTimeoutMs() + 5000;
         while (System.currentTimeMillis() - start < safeShutdownTimeoutMs) {
           redLightStrategies = redLightStrategies.stream().filter((s) -> {
             try {

--- a/core/src/main/java/com/transferwise/common/gracefulshutdown/GracefulShutdowner.java
+++ b/core/src/main/java/com/transferwise/common/gracefulshutdown/GracefulShutdowner.java
@@ -37,14 +37,14 @@ public class GracefulShutdowner implements ApplicationListener<ApplicationReadyE
   private DefaultLifecycleProcessor defaultLifecycleProcessor;
 
   private boolean started;
-  private AtomicBoolean isShuttingDown = new AtomicBoolean(false);
+  private final AtomicBoolean isShuttingDown = new AtomicBoolean(false);
 
   @PostConstruct
   public void init() {
     log.info("Initialized graceful shutdown with timeout {} ms. Client reaction timeout will be {} ms.",
         properties.getShutdownTimeoutMs(), properties.getClientsReactionTimeMs());
     if (defaultLifecycleProcessor != null) {
-      defaultLifecycleProcessor.setTimeoutPerShutdownPhase(2 * (properties.getClientsReactionTimeMs() + properties.getShutdownTimeoutMs()));
+      defaultLifecycleProcessor.setTimeoutPerShutdownPhase(2L * (properties.getClientsReactionTimeMs() + properties.getShutdownTimeoutMs()));
     }
   }
 
@@ -83,9 +83,9 @@ public class GracefulShutdowner implements ApplicationListener<ApplicationReadyE
         long start = System.currentTimeMillis();
         List<GracefulShutdownStrategy> redLightStrategies = new ArrayList<>(strategies);
 
-        // slightly increase timeout here
-        // now strategies could safely try to shut down within GracefulShutdownProperties.getShutdownTimeoutMs()
-        int safeShutdownTimeoutMs = properties.getShutdownTimeoutMs() + 500;
+        // increase timeout here
+        // now strategies could safely try to shut down within GracefulShutdownProperties.getStrategyShutdownTimeout()
+        int safeShutdownTimeoutMs = properties.getStrategyShutdownTimeout() + 5000;
         while (System.currentTimeMillis() - start < safeShutdownTimeoutMs) {
           redLightStrategies = redLightStrategies.stream().filter((s) -> {
             try {

--- a/core/src/main/java/com/transferwise/common/gracefulshutdown/config/GracefulShutdownProperties.java
+++ b/core/src/main/java/com/transferwise/common/gracefulshutdown/config/GracefulShutdownProperties.java
@@ -13,4 +13,8 @@ public class GracefulShutdownProperties {
   private int clientsReactionTimeMs = 30000;
 
   private int strategiesCheckIntervalTimeMs = 5000;
+
+  public int getStrategyShutdownTimeout() {
+    return shutdownTimeoutMs * 2;
+  }
 }

--- a/core/src/main/java/com/transferwise/common/gracefulshutdown/config/GracefulShutdownProperties.java
+++ b/core/src/main/java/com/transferwise/common/gracefulshutdown/config/GracefulShutdownProperties.java
@@ -8,13 +8,9 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @SuppressWarnings("checkstyle:magicnumber")
 public class GracefulShutdownProperties {
 
-  private int shutdownTimeoutMs = 60000;
+  private int shutdownTimeoutMs = 90_000;
 
-  private int clientsReactionTimeMs = 30000;
+  private int clientsReactionTimeMs = 30_000;
 
-  private int strategiesCheckIntervalTimeMs = 5000;
-
-  public int getStrategyShutdownTimeout() {
-    return shutdownTimeoutMs * 2;
-  }
+  private int strategiesCheckIntervalTimeMs = 5_000;
 }

--- a/core/src/main/java/com/transferwise/common/gracefulshutdown/strategies/BaseReactiveResourceShutdownStrategy.java
+++ b/core/src/main/java/com/transferwise/common/gracefulshutdown/strategies/BaseReactiveResourceShutdownStrategy.java
@@ -60,7 +60,7 @@ public abstract class BaseReactiveResourceShutdownStrategy<T> implements Gracefu
    * @return {@link Duration}
    */
   protected Duration getStrategyShutdownTimeout() {
-    return Duration.ofMillis(this.gracefulShutdownProperties.getStrategyShutdownTimeout());
+    return Duration.ofMillis(this.gracefulShutdownProperties.getShutdownTimeoutMs());
   }
 
   /**
@@ -69,9 +69,9 @@ public abstract class BaseReactiveResourceShutdownStrategy<T> implements Gracefu
    */
   protected int getResourceFullShutdownTimeoutMs() {
     // resource should shut down a little earlier than StrategyShutdownTimeout
-    int result = this.gracefulShutdownProperties.getStrategyShutdownTimeout() - 250;
+    int result = this.gracefulShutdownProperties.getShutdownTimeoutMs() - 250;
     if (result < 1000) {
-      result = this.gracefulShutdownProperties.getStrategyShutdownTimeout();
+      result = this.gracefulShutdownProperties.getShutdownTimeoutMs();
     }
 
     return result;

--- a/core/src/main/java/com/transferwise/common/gracefulshutdown/strategies/BaseReactiveResourceShutdownStrategy.java
+++ b/core/src/main/java/com/transferwise/common/gracefulshutdown/strategies/BaseReactiveResourceShutdownStrategy.java
@@ -1,0 +1,200 @@
+package com.transferwise.common.gracefulshutdown.strategies;
+
+import com.transferwise.common.gracefulshutdown.GracefulShutdownStrategy;
+import com.transferwise.common.gracefulshutdown.config.GracefulShutdownProperties;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationContext;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
+
+@Slf4j
+public abstract class BaseReactiveResourceShutdownStrategy<T> implements GracefulShutdownStrategy {
+
+  public BaseReactiveResourceShutdownStrategy(@NonNull Class<T> resourceType, @NonNull ApplicationContext applicationContext,
+      @NonNull GracefulShutdownProperties gracefulShutdownProperties) {
+    this.resourceType = resourceType;
+    this.applicationContext = applicationContext;
+    this.gracefulShutdownProperties = gracefulShutdownProperties;
+  }
+
+
+  @NonNull
+  // Because of Java type erasure we can't get type of generic parameter after compilation.
+  // To access it at runtime we have to provide and save it explicitly.
+  private final Class<T> resourceType;
+
+  protected Class<T> getResourceType() {
+    return this.resourceType;
+  }
+
+  @NonNull
+  private final ApplicationContext applicationContext;
+
+
+  @Getter(AccessLevel.PROTECTED)
+  @NonNull
+  private final GracefulShutdownProperties gracefulShutdownProperties;
+
+  /**
+   * Will delay strategy shutdown for this {@link Duration}.
+   * @return {@link Duration}
+   */
+  protected Duration getStrategyShutdownDelay() {
+    return Duration.ZERO;
+  }
+
+  /**
+   * {@link Duration} allowed for strategy to shut down all resources.
+   * @return {@link Duration}
+   */
+  protected Duration getStrategyShutdownTimeout() {
+    return Duration.ofMillis(this.gracefulShutdownProperties.getShutdownTimeoutMs());
+  }
+
+  /**
+   * Time in Ms within resource should shut down.
+   * @return Time in Ms
+   */
+  protected int getResourceFullShutdownTimeoutMs() {
+    // resource should shut down a little earlier than ShutdownTimeoutMs
+    int result = this.gracefulShutdownProperties.getShutdownTimeoutMs() - 250;
+    if (result < 1000) {
+      result = this.gracefulShutdownProperties.getShutdownTimeoutMs();
+    }
+
+    return result;
+  }
+
+  /**
+   * {@link Duration} allowed for resource to shut down gracefully. If not shut down within this time -
+   * {@link BaseReactiveResourceShutdownStrategy#shutdownResourceForced} will be called.
+   * @return {@link Duration}
+   */
+  protected Duration getResourceGracefulShutdownTimeout() {
+    // use 9/10 of time full shut down time to graceful shutdown
+    return Duration.ofMillis(getResourceFullShutdownTimeoutMs() / 10 * 9);
+  }
+
+  /**
+   * {@link Duration} allowed for resource to force shut down. If not shut down within this time - error will be logged.
+   * @return {@link Duration}
+   */
+  protected Duration getResourceForcedShutdownTimeout() {
+    // use 1/10 of time full shut down time to force shutdown
+    return Duration.ofMillis(getResourceFullShutdownTimeoutMs() / 10);
+  }
+
+
+  @Getter(AccessLevel.PROTECTED)
+  private final Scheduler shutdownScheduler = Schedulers.newBoundedElastic(
+      10,
+      100_000,
+      "ShutdownWorker_" + this.getClass().getSimpleName()
+  );
+
+  private final List<T> addedResources = new ArrayList<>();
+
+  private final AtomicBoolean isShutdownAllowed = new AtomicBoolean(false);
+
+  /**
+   * Default implementation of {@link GracefulShutdownStrategy#prepareForShutdown()}. Will search in {@link ApplicationContext} for Beans of
+   * {@link Class} type provided by {@link BaseReactiveResourceShutdownStrategy#getResourceType()} union them wth externally added resources by
+   * {@link BaseReactiveResourceShutdownStrategy#addResource} and then shut down them all.
+   */
+  @Override
+  public void prepareForShutdown() {
+
+    Collection<T> resourceBeans = applicationContext.getBeansOfType(getResourceType()).values();
+    Set<T> allResources = new HashSet<>(resourceBeans);
+    allResources.addAll(addedResources);
+
+    shutdownResources(allResources)
+        .delaySubscription(getStrategyShutdownDelay(), getShutdownScheduler())
+        .subscribeOn(getShutdownScheduler())
+        .subscribe();
+  }
+
+  private Mono<Void> shutdownResources(@NonNull Collection<T> shutdownResources) {
+    return Flux.fromIterable(shutdownResources)
+        // Will start shutting down in parallel
+        .parallel()
+        .runOn(getShutdownScheduler())
+        .flatMap(resource -> {
+          String resourceName = getResourceType().getSimpleName();
+          String resourceDescription = resource.toString();
+
+          return this.shutdownResourceGraceful(resource)
+              .doOnError((throwable) -> log.warn("Error while graceful shutting down {}", resourceName, throwable))
+              .doOnSuccess((e) -> log.info("{} gracefully stopped: {}.", resourceName, resourceDescription))
+              .doOnSubscribe(e -> log.info("Shutting down {} gracefully: '{}'.", resourceName, resourceDescription))
+              .timeout(this.getResourceGracefulShutdownTimeout())
+              // Our flow will try to force shut down in case of error on graceful shutting down any resource
+              .onErrorResume(throwable ->
+                  shutdownResourceForced(resource)
+                      .doOnSuccess((e) -> log.info("{} force stopped: {}.", resourceName, resourceDescription))
+                      .doOnSubscribe(e -> log.info("Shutting down {} forcefully: '{}'.", resourceName, resourceDescription))
+                      .timeout(this.getResourceForcedShutdownTimeout()))
+              // Our flow will continue in case of error on force shut down any resource
+              .onErrorResume(throwableForce -> {
+                log.error("Error while shutting down {}", resourceName, throwableForce);
+                return Mono.empty();
+              });
+        })
+        // We interested only when everything is completed, so skip individual signals of shut down resources
+        .then()
+        // Should fail with error in case all resources is not shut down in time.
+        .timeout(this.getStrategyShutdownTimeout())
+        .doOnSubscribe((s) -> log.info("Starting shutdown of resources: {}", getResourceType().getSimpleName()))
+        .doOnError(throwable -> log.error("Error while shutting down all {}", getResourceType().getSimpleName(), throwable))
+        .doOnSuccess((s) -> log.info("All resources stopped"))
+        .doOnTerminate(() -> isShutdownAllowed.set(true));
+  }
+
+  /**
+   * Method will be called to gracefully shut down resource.
+   * <p>
+   * Example: {@link ExecutorServiceGracefulShutdownStrategy#shutdownResourceGraceful}
+   * </p>
+   *
+   * @param resource Resource to shut down.
+   * @return {@link Mono} with graceful shutdown task.
+   */
+  protected abstract Mono<Void> shutdownResourceGraceful(@NonNull T resource);
+
+  /**
+   * Method will be called to force shut down resource if graceful shutdown is failed.
+   * <p>
+   * Example: {@link ExecutorServiceGracefulShutdownStrategy#shutdownResourceForced}
+   * </p>
+   *
+   * @param resource Resource to shut down.
+   * @return {@link Mono} with force shutdown task.
+   */
+  protected abstract Mono<Void> shutdownResourceForced(@NonNull T resource);
+
+
+  /**
+   * Will shut down gracefully added resources during app shutdown.
+   * @param resource Resource to shut down gracefully.
+   */
+  public void addResource(T resource) {
+    addedResources.add(resource);
+  }
+
+  @Override
+  public boolean canShutdown() {
+    return isShutdownAllowed.get();
+  }
+}

--- a/core/src/main/java/com/transferwise/common/gracefulshutdown/strategies/BaseReactiveResourceShutdownStrategy.java
+++ b/core/src/main/java/com/transferwise/common/gracefulshutdown/strategies/BaseReactiveResourceShutdownStrategy.java
@@ -60,7 +60,7 @@ public abstract class BaseReactiveResourceShutdownStrategy<T> implements Gracefu
    * @return {@link Duration}
    */
   protected Duration getStrategyShutdownTimeout() {
-    return Duration.ofMillis(this.gracefulShutdownProperties.getShutdownTimeoutMs());
+    return Duration.ofMillis(this.gracefulShutdownProperties.getStrategyShutdownTimeout());
   }
 
   /**
@@ -68,10 +68,10 @@ public abstract class BaseReactiveResourceShutdownStrategy<T> implements Gracefu
    * @return Time in Ms
    */
   protected int getResourceFullShutdownTimeoutMs() {
-    // resource should shut down a little earlier than ShutdownTimeoutMs
-    int result = this.gracefulShutdownProperties.getShutdownTimeoutMs() - 250;
+    // resource should shut down a little earlier than StrategyShutdownTimeout
+    int result = this.gracefulShutdownProperties.getStrategyShutdownTimeout() - 250;
     if (result < 1000) {
-      result = this.gracefulShutdownProperties.getShutdownTimeoutMs();
+      result = this.gracefulShutdownProperties.getStrategyShutdownTimeout();
     }
 
     return result;

--- a/core/src/main/java/com/transferwise/common/gracefulshutdown/strategies/ExecutorServiceGracefulShutdownStrategy.java
+++ b/core/src/main/java/com/transferwise/common/gracefulshutdown/strategies/ExecutorServiceGracefulShutdownStrategy.java
@@ -1,0 +1,78 @@
+package com.transferwise.common.gracefulshutdown.strategies;
+
+import com.transferwise.common.gracefulshutdown.config.GracefulShutdownProperties;
+import com.transferwise.common.gracefulshutdown.utils.ExecutorShutdownUtils;
+import java.time.Duration;
+import java.util.concurrent.ExecutorService;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationContext;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+public class ExecutorServiceGracefulShutdownStrategy extends BaseReactiveResourceShutdownStrategy<ExecutorService> {
+
+  private final Duration delayBetweenTerminationCheck = Duration.ofMillis(250);
+
+  @Override
+  protected Duration getStrategyShutdownDelay() {
+    // In case shutdown was called right after call to endpoint:
+    // this will give time for endpoint using ExecutorService to send task if required.
+    return Duration.ofMillis(getResourceFullShutdownTimeoutMs() / 2);
+  }
+
+  @Override
+  protected Duration getResourceGracefulShutdownTimeout() {
+    // half of getResourceFullShutdownTimeoutMs was used in getStrategyShutdownDelay
+    // use 4/10 of full resource shutdown time for graceful shutdown
+    return Duration.ofMillis(getResourceFullShutdownTimeoutMs() / 10 * 4);
+  }
+
+  @Override
+  protected Duration getResourceForcedShutdownTimeout() {
+    // use remaining 1/10 of full resource shutdown time for graceful shutdown
+    return Duration.ofMillis(getResourceFullShutdownTimeoutMs() / 10);
+  }
+
+  public ExecutorServiceGracefulShutdownStrategy(ApplicationContext applicationContext, GracefulShutdownProperties gracefulShutdownProperties) {
+    super(ExecutorService.class, applicationContext, gracefulShutdownProperties);
+  }
+
+  @Override
+  protected Mono<Void> shutdownResourceGraceful(@NonNull ExecutorService resource) {
+    return Mono.fromRunnable(() -> ExecutorShutdownUtils.shutdownExecutor(resource, true))
+        // Do not emit complete until ExecutorService termination
+        .then(waitTermination(resource));
+  }
+
+  @Override
+  protected Mono<Void> shutdownResourceForced(@NonNull ExecutorService resource) {
+    return Mono.fromRunnable(resource::shutdownNow)
+        .then(waitTermination(resource));
+  }
+
+  private Mono<Boolean> checkTermination(ExecutorService resource) {
+    return Mono.fromCallable(resource::isTerminated);
+  }
+
+  /**
+   * Will check for termination status in non-blocking way. No thread will be waiting.
+   *
+   * @param resource {@link ExecutorService} to wait for termination.
+   * @return {@link Mono} that will complete only when {@link #checkTermination} will return true
+   */
+  private Mono<Void> waitTermination(ExecutorService resource) {
+    return checkTermination(resource)
+        // Use expand as this allows to repeatedly call functions based on previous call result with a breadth-first approach.
+        // Call stack will not be polluted.
+        .expand(isTerminated -> {
+          if (!isTerminated) {
+            return checkTermination(resource)
+                .delaySubscription(this.delayBetweenTerminationCheck);
+          } else {
+            // Empty Mono signals as exit from expand
+            return Mono.empty();
+          }
+        }).then();
+  }
+}

--- a/core/src/main/java/com/transferwise/common/gracefulshutdown/strategies/TaskSchedulersGracefulShutdownStrategy.java
+++ b/core/src/main/java/com/transferwise/common/gracefulshutdown/strategies/TaskSchedulersGracefulShutdownStrategy.java
@@ -8,6 +8,10 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
@@ -16,21 +20,24 @@ import org.springframework.scheduling.concurrent.ConcurrentTaskScheduler;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
 @Slf4j
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(toBuilder = true)
 public class TaskSchedulersGracefulShutdownStrategy implements GracefulShutdownStrategy {
 
   @Autowired
   private ApplicationContext applicationContext;
 
-  private List<TaskScheduler> taskSchedulers = new ArrayList<>();
+  private final List<TaskScheduler> taskSchedulers = new ArrayList<>();
 
-  private AtomicInteger inProgressShutdowns = new AtomicInteger();
+  private final AtomicInteger inProgressShutdowns = new AtomicInteger();
 
   @Override
   public void prepareForShutdown() {
     var executors = Executors.newFixedThreadPool(10);
 
     var taskSchedulerBeans = applicationContext.getBeansOfType(TaskScheduler.class).values();
-    var allTaskSchedulers = new HashSet(taskSchedulerBeans);
+    var allTaskSchedulers = new HashSet<>(taskSchedulerBeans);
     allTaskSchedulers.addAll(taskSchedulers);
 
     for (var taskSchedulerProto : allTaskSchedulers) {

--- a/core/src/main/java/com/transferwise/common/gracefulshutdown/strategies/TaskSchedulersGracefulShutdownStrategy.java
+++ b/core/src/main/java/com/transferwise/common/gracefulshutdown/strategies/TaskSchedulersGracefulShutdownStrategy.java
@@ -1,14 +1,13 @@
 package com.transferwise.common.gracefulshutdown.strategies;
 
 import com.transferwise.common.gracefulshutdown.GracefulShutdownStrategy;
+import com.transferwise.common.gracefulshutdown.utils.ExecutorShutdownUtils;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
-import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.atomic.AtomicInteger;
-
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
@@ -16,8 +15,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.scheduling.TaskScheduler;
-import org.springframework.scheduling.concurrent.ConcurrentTaskScheduler;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
 @Slf4j
 @NoArgsConstructor
@@ -45,49 +42,11 @@ public class TaskSchedulersGracefulShutdownStrategy implements GracefulShutdownS
       executors.submit(() -> {
         var taskScheduler = taskSchedulerProto;
         try {
-          if (taskScheduler instanceof ThreadPoolTaskScheduler) {
-            log.info("Shutting down thread pool task scheduler '{}'.", taskScheduler);
-            var threadPoolTaskScheduler = (ThreadPoolTaskScheduler) taskScheduler;
-
-            var scheduledThreadPoolExecutor = threadPoolTaskScheduler.getScheduledThreadPoolExecutor();
-            scheduledThreadPoolExecutor.setExecuteExistingDelayedTasksAfterShutdownPolicy(false);
-            scheduledThreadPoolExecutor.setContinueExistingPeriodicTasksAfterShutdownPolicy(false);
-            scheduledThreadPoolExecutor.getQueue().clear();
-            threadPoolTaskScheduler.setWaitForTasksToCompleteOnShutdown(true);
-            threadPoolTaskScheduler.shutdown();
-          } else if (taskScheduler instanceof ConcurrentTaskScheduler) {
-            log.info("Shutting down concurrent task scheduler '{}'.", taskScheduler);
-            var concurrentTaskScheduler = (ConcurrentTaskScheduler) taskScheduler;
-            var executor = concurrentTaskScheduler.getConcurrentExecutor();
-
-            if (executor instanceof ScheduledThreadPoolExecutor) {
-              var scheduledThreadPoolExecutor = (ScheduledThreadPoolExecutor) executor;
-              scheduledThreadPoolExecutor.setContinueExistingPeriodicTasksAfterShutdownPolicy(false);
-              scheduledThreadPoolExecutor.setExecuteExistingDelayedTasksAfterShutdownPolicy(false);
-              scheduledThreadPoolExecutor.getQueue().clear();
-              scheduledThreadPoolExecutor.shutdown();
-            } else if (executor instanceof ExecutorService) {
-              ((ExecutorService) executor).shutdown();
-            } else {
-              try {
-                var shutdownMethod = executor.getClass().getMethod("shutdown");
-                shutdownMethod.invoke(executor);
-              } catch (NoSuchMethodException ignored) {
-                // ignored
-              } catch (Throwable t) {
-                log.error("Shutting down concurrent task scheduler executor failed.", t);
-              }
-            }
+          if (taskScheduler instanceof Executor) {
+            ExecutorShutdownUtils.shutdownExecutor((Executor) taskScheduler, false);
           } else {
-            try {
-              var shutdownMethod = taskScheduler.getClass().getMethod("shutdown");
-              log.info("Shutting down unknown task scheduler '{}' using it's 'shutdown()' method.", taskScheduler);
-              shutdownMethod.invoke(taskScheduler);
-            } catch (NoSuchMethodException ignored) {
-              log.warn("Found a task scheduler '{}', but do not know how to shut it down. Please contact SRE team.", taskScheduler);
-            } catch (Throwable t) {
-              log.error("Shutting down concurrent task scheduler executor failed.", t);
-            }
+            log.info("Shutting down unknown task scheduler '{}' using it's 'shutdown()' method.", taskScheduler);
+            ExecutorShutdownUtils.shutdownExecutorWithReflection(taskScheduler, true);
           }
         } catch (Throwable t) {
           log.error("Stopping a task scheduler failed.", t);

--- a/core/src/main/java/com/transferwise/common/gracefulshutdown/strategies/TaskSchedulersGracefulShutdownStrategy.java
+++ b/core/src/main/java/com/transferwise/common/gracefulshutdown/strategies/TaskSchedulersGracefulShutdownStrategy.java
@@ -8,22 +8,16 @@ import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.scheduling.TaskScheduler;
 
 @Slf4j
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder(toBuilder = true)
+@RequiredArgsConstructor
 public class TaskSchedulersGracefulShutdownStrategy implements GracefulShutdownStrategy {
 
-  @Autowired
-  private ApplicationContext applicationContext;
+  private final ApplicationContext applicationContext;
 
   private final List<TaskScheduler> taskSchedulers = new ArrayList<>();
 

--- a/core/src/main/java/com/transferwise/common/gracefulshutdown/utils/ExecutorShutdownUtils.java
+++ b/core/src/main/java/com/transferwise/common/gracefulshutdown/utils/ExecutorShutdownUtils.java
@@ -1,0 +1,84 @@
+package com.transferwise.common.gracefulshutdown.utils;
+
+import java.lang.reflect.Method;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.concurrent.ConcurrentTaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+@Slf4j
+public abstract class ExecutorShutdownUtils {
+
+  /** Will execute appropriate methods to shut down Executor.
+   * @param executor                     {@link Executor} to shutdown
+   * @param askToReportOnUnknownExecutor in case of unknown {@link Executor} and absence of shutdown() method warning will be logged with request to
+   *                                     contact SRE
+   */
+  public static void shutdownExecutor(Executor executor, boolean askToReportOnUnknownExecutor) {
+    if (executor instanceof ThreadPoolTaskScheduler) {
+      log.info("Shutting down thread pool task scheduler '{}'.", executor);
+      shutdownThreadPoolTaskScheduler((ThreadPoolTaskScheduler) executor);
+    } else if (executor instanceof ConcurrentTaskScheduler) {
+      log.info("Shutting down concurrent task scheduler '{}'.", executor);
+      shutdownConcurrentTaskScheduler((ConcurrentTaskScheduler) executor);
+    } else if (executor instanceof ScheduledThreadPoolExecutor) {
+      log.info("Shutting down scheduled task scheduler '{}'.", executor);
+      shutdownScheduledThreadPoolExecutor((ScheduledThreadPoolExecutor) executor);
+    } else if (executor instanceof ExecutorService) {
+      log.info("Shutting down ExecutorService '{}'.", executor);
+      shutdownExecutorService((ExecutorService) executor);
+    } else {
+      log.info("Shutting down unknown executor '{}' using it's 'shutdown()' method.", executor);
+      shutdownExecutorWithReflection(executor, askToReportOnUnknownExecutor);
+    }
+  }
+
+  /**
+   * Will try to get <b>shutdown()</b> method with reflection and run it on provided Object.
+   *
+   * @param executor                     Executor to shut down
+   * @param askToReportOnUnknownExecutor In case of absence of shutdown() method warning will be logged with request to contact SRE
+   */
+  public static void shutdownExecutorWithReflection(Object executor, boolean askToReportOnUnknownExecutor) {
+    try {
+      Method shutdownMethod = executor.getClass().getMethod("shutdown");
+      shutdownMethod.invoke(executor);
+    } catch (NoSuchMethodException noSuchMethodException) {
+      if (askToReportOnUnknownExecutor) {
+        log.warn("Found an executor '{}', but do not know how to shut it down. Please contact SRE team.",
+            executor.getClass().getSimpleName(),
+            noSuchMethodException
+        );
+      }
+    } catch (Throwable t) {
+      log.error("Shutting down executor failed.", t);
+    }
+  }
+
+  private static void shutdownExecutorService(ExecutorService executorService) {
+    executorService.shutdown();
+  }
+
+  private static void shutdownThreadPoolTaskScheduler(ThreadPoolTaskScheduler threadPoolTaskScheduler) {
+    ScheduledThreadPoolExecutor scheduledThreadPoolExecutor = threadPoolTaskScheduler.getScheduledThreadPoolExecutor();
+    scheduledThreadPoolExecutor.setExecuteExistingDelayedTasksAfterShutdownPolicy(false);
+    scheduledThreadPoolExecutor.setContinueExistingPeriodicTasksAfterShutdownPolicy(false);
+    scheduledThreadPoolExecutor.getQueue().clear();
+    threadPoolTaskScheduler.setWaitForTasksToCompleteOnShutdown(true);
+    threadPoolTaskScheduler.shutdown();
+  }
+
+  private static void shutdownConcurrentTaskScheduler(ConcurrentTaskScheduler concurrentTaskScheduler) {
+    Executor executor = concurrentTaskScheduler.getConcurrentExecutor();
+    shutdownExecutor(executor, false);
+  }
+
+  private static void shutdownScheduledThreadPoolExecutor(ScheduledThreadPoolExecutor scheduledThreadPoolExecutor) {
+    scheduledThreadPoolExecutor.setExecuteExistingDelayedTasksAfterShutdownPolicy(false);
+    scheduledThreadPoolExecutor.setContinueExistingPeriodicTasksAfterShutdownPolicy(false);
+    scheduledThreadPoolExecutor.getQueue().clear();
+    scheduledThreadPoolExecutor.shutdown();
+  }
+}

--- a/core/src/test/java/com/transferwise/common/gracefulshutdown/GracefulShutdownerIntTest.java
+++ b/core/src/test/java/com/transferwise/common/gracefulshutdown/GracefulShutdownerIntTest.java
@@ -8,14 +8,13 @@ import com.transferwise.common.gracefulshutdown.strategies.KagkarlssonDbSchedule
 import com.transferwise.common.gracefulshutdown.strategies.RequestCountGracefulShutdownStrategy;
 import com.transferwise.common.gracefulshutdown.strategies.TaskSchedulersGracefulShutdownStrategy;
 import com.transferwise.common.gracefulshutdown.test.TestApplication;
+import java.time.Duration;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.health.Status;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
-
-import java.time.Duration;
 
 @ActiveProfiles({"test"})
 @SpringBootTest(classes = {TestApplication.class})

--- a/core/src/test/java/com/transferwise/common/gracefulshutdown/GracefulShutdownerIntTest.java
+++ b/core/src/test/java/com/transferwise/common/gracefulshutdown/GracefulShutdownerIntTest.java
@@ -15,6 +15,8 @@ import org.springframework.boot.actuate.health.Status;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
+import java.time.Duration;
+
 @ActiveProfiles({"test"})
 @SpringBootTest(classes = {TestApplication.class})
 class GracefulShutdownerIntTest {
@@ -55,8 +57,7 @@ class GracefulShutdownerIntTest {
 
     final var newSchedulerCounterValue = testApplication.schedulerCounter.get();
 
-    // No idea, how to make it without sleep. We want to check if the scheduling stopped.
-    Thread.sleep(50);
+    await().atMost(Duration.ofSeconds(1)).until(() -> !gracefulShutdowner.isRunning());
     assertThat(testApplication.schedulerCounter.get()).isEqualTo(newSchedulerCounterValue);
 
     assertThat(gracefulShutdowner.isRunning()).isFalse();

--- a/core/src/test/java/com/transferwise/common/gracefulshutdown/strategies/ExecutorServiceGracefulShutdownStrategyTest.java
+++ b/core/src/test/java/com/transferwise/common/gracefulshutdown/strategies/ExecutorServiceGracefulShutdownStrategyTest.java
@@ -1,0 +1,174 @@
+package com.transferwise.common.gracefulshutdown.strategies;
+
+import com.transferwise.common.gracefulshutdown.config.GracefulShutdownProperties;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.atomic.AtomicBoolean;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.context.support.StaticApplicationContext;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+@Execution(ExecutionMode.CONCURRENT)
+class ExecutorServiceGracefulShutdownStrategyTest {
+
+  private static final Duration submittedTaskRunTime = Duration.ofSeconds(30);
+  private static final Duration checkMaxWaitTime = Duration.ofSeconds(25);
+
+  private static final GracefulShutdownProperties gracefulShutdownProperties;
+
+  static {
+    gracefulShutdownProperties = new GracefulShutdownProperties();
+    gracefulShutdownProperties.setShutdownTimeoutMs((int) Duration.ofSeconds(5).toMillis());
+  }
+
+  @Test
+  public void shutdown_invoked_on_application_context_classes() {
+    // GIVEN
+    StaticApplicationContext applicationContext = new StaticApplicationContext();
+    ExecutorServiceGracefulShutdownStrategy strategy = new ExecutorServiceGracefulShutdownStrategy(
+        applicationContext,
+        gracefulShutdownProperties
+    );
+    ScheduledThreadPoolExecutor scheduledThreadPoolExecutor = new ScheduledThreadPoolExecutor(1);
+    ConfigurableListableBeanFactory beanFactory = applicationContext.getBeanFactory();
+    beanFactory.registerSingleton("test", scheduledThreadPoolExecutor);
+
+    // WHEN
+    strategy.prepareForShutdown();
+
+    // THEN
+    Awaitility.await().atMost(checkMaxWaitTime).until(scheduledThreadPoolExecutor::isTerminated);
+    Awaitility.await().atMost(checkMaxWaitTime).until(strategy::canShutdown);
+  }
+
+  @Test
+  public void shutdown_invoked_on_external_added_classes() {
+    // GIVEN
+    ExecutorServiceGracefulShutdownStrategy strategy = new ExecutorServiceGracefulShutdownStrategy(
+        new StaticApplicationContext(),
+        gracefulShutdownProperties
+    );
+    ExecutorService executorService = Executors.newFixedThreadPool(1);
+    strategy.addResource(executorService);
+
+    // WHEN
+    strategy.prepareForShutdown();
+
+    // THEN
+    Awaitility.await().atMost(checkMaxWaitTime).until(executorService::isTerminated);
+    Awaitility.await().atMost(checkMaxWaitTime).until(strategy::canShutdown);
+  }
+
+  @Test
+  public void shutdown_timeout_is_applied_and_called_shutdownNow() {
+    // GIVEN
+    AtomicBoolean isInterrupted = new AtomicBoolean(false);
+
+    ExecutorServiceGracefulShutdownStrategy strategy = new ExecutorServiceGracefulShutdownStrategy(
+        new StaticApplicationContext(),
+        gracefulShutdownProperties
+    );
+    ExecutorService executorService = Executors.newFixedThreadPool(1);
+    strategy.addResource(executorService);
+    executorService.execute(() -> {
+      try {
+        Thread.sleep(checkMaxWaitTime.toMillis());
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        isInterrupted.set(true);
+      }
+    });
+
+    // WHEN
+    strategy.prepareForShutdown();
+
+    // THEN
+    Awaitility.await().atMost(checkMaxWaitTime).until(executorService::isTerminated);
+    Awaitility.await().atMost(checkMaxWaitTime).until(strategy::canShutdown);
+    Assertions.assertTrue(isInterrupted.get());
+  }
+
+  @Test
+  @Disabled("For development only")
+  public void shutdown_runs_in_multiple_treads() {
+    // GIVEN
+    int processorsCount = Runtime.getRuntime().availableProcessors();
+    if (processorsCount < 2) {
+      log.warn("Test requires proper parallel execution");
+      return;
+    }
+
+    ExecutorServiceGracefulShutdownStrategy strategy = new ExecutorServiceGracefulShutdownStrategy(
+        new StaticApplicationContext(),
+        gracefulShutdownProperties
+    ) {
+      // need to add blocking as ExecutorService.shutdown() returns immediately
+      @Override
+      protected Mono<Void> shutdownResourceGraceful(@NonNull ExecutorService resource) {
+        try {
+          // Waiting here, so we block calling thread.
+          // Goal is to fail test if not run in multiple threads.
+          // Because each thread will sleep for submittedTaskRunTime seconds before shutdown,
+          // it will be unable to start shutting down all executors before shutdown check completes
+          // ExecutorService count * sleep time > Wait time for ExecutorService::isShutdown check
+
+          //noinspection BlockingMethodInNonBlockingContext
+          Thread.sleep(gracefulShutdownProperties.getShutdownTimeoutMs() / 3);
+        } catch (InterruptedException e) {
+          throw new RuntimeException(e);
+        }
+        log.info("Waiting complete");
+
+        return super.shutdownResourceGraceful(resource)
+            .doOnSubscribe((s) -> log.info("Starting shutdown"));
+      }
+    };
+
+    List<ExecutorService> executorServiceList = new ArrayList<>();
+
+    for (int executorServiceCount = 0; executorServiceCount < 8; executorServiceCount++) {
+      ExecutorService executorService = Executors.newFixedThreadPool(1);
+      executorServiceList.add(executorService);
+      executorService.execute(() -> {
+        try {
+          Thread.sleep(submittedTaskRunTime.toMillis());
+          log.info("Completed");
+        } catch (InterruptedException e) {
+          log.info("Task interrupted");
+        }
+      });
+
+      strategy.addResource(executorService);
+    }
+
+    // WHEN
+    strategy.prepareForShutdown();
+
+    // THEN
+
+    // shutdown should be called almost immediately if shutdown started in parallel
+    Awaitility.await().atMost(Duration.ofMillis(gracefulShutdownProperties.getShutdownTimeoutMs())).until(() ->
+        executorServiceList.stream().allMatch(ExecutorService::isShutdown)
+    );
+
+    // all task should complete within this time if run in parallel
+    Awaitility.await().atMost(checkMaxWaitTime).until(() ->
+        executorServiceList.stream().allMatch(ExecutorService::isTerminated)
+    );
+
+    Awaitility.await().atMost(checkMaxWaitTime).until(strategy::canShutdown);
+  }
+}

--- a/core/src/test/java/com/transferwise/common/gracefulshutdown/strategies/TaskSchedulersGracefulShutdownStrategyTest.java
+++ b/core/src/test/java/com/transferwise/common/gracefulshutdown/strategies/TaskSchedulersGracefulShutdownStrategyTest.java
@@ -1,6 +1,5 @@
 package com.transferwise.common.gracefulshutdown.strategies;
 
-import java.lang.reflect.Field;
 import java.util.concurrent.Executors;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
@@ -10,16 +9,16 @@ import org.springframework.scheduling.concurrent.ConcurrentTaskScheduler;
 class TaskSchedulersGracefulShutdownStrategyTest {
 
   @Test
-  public void shutdown_invoked_on_private_classes() throws NoSuchFieldException, IllegalAccessException {
+  public void shutdown_invoked_on_private_classes() {
     // GIVEN
+    var strategy = new TaskSchedulersGracefulShutdownStrategy();
+    strategy = strategy.toBuilder()
+            .applicationContext(new StaticApplicationContext())
+            .build();
+
     var executor = Executors.newSingleThreadScheduledExecutor();
     var scheduler = new ConcurrentTaskScheduler(executor);
-    var strategy = new TaskSchedulersGracefulShutdownStrategy();
     strategy.addTaskScheduler(scheduler);
-
-    Field field = TaskSchedulersGracefulShutdownStrategy.class.getDeclaredField("applicationContext");
-    field.setAccessible(true);
-    field.set(strategy, new StaticApplicationContext());
 
     // WHEN
     strategy.prepareForShutdown();

--- a/core/src/test/java/com/transferwise/common/gracefulshutdown/strategies/TaskSchedulersGracefulShutdownStrategyTest.java
+++ b/core/src/test/java/com/transferwise/common/gracefulshutdown/strategies/TaskSchedulersGracefulShutdownStrategyTest.java
@@ -11,10 +11,7 @@ class TaskSchedulersGracefulShutdownStrategyTest {
   @Test
   public void shutdown_invoked_on_private_classes() {
     // GIVEN
-    var strategy = new TaskSchedulersGracefulShutdownStrategy();
-    strategy = strategy.toBuilder()
-            .applicationContext(new StaticApplicationContext())
-            .build();
+    var strategy = new TaskSchedulersGracefulShutdownStrategy(new StaticApplicationContext());
 
     var executor = Executors.newSingleThreadScheduledExecutor();
     var scheduler = new ConcurrentTaskScheduler(executor);

--- a/core/src/test/java/com/transferwise/common/gracefulshutdown/utils/ExecutorShutdownUtilsTest.java
+++ b/core/src/test/java/com/transferwise/common/gracefulshutdown/utils/ExecutorShutdownUtilsTest.java
@@ -1,0 +1,161 @@
+package com.transferwise.common.gracefulshutdown.utils;
+
+import java.time.Duration;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.atomic.AtomicBoolean;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.springframework.scheduling.concurrent.ConcurrentTaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+@Slf4j
+@Execution(ExecutionMode.CONCURRENT)
+class ExecutorShutdownUtilsTest {
+
+  private static final Duration submittedTaskRunTime = Duration.ofSeconds(2);
+  private static final Duration checkMaxWaitTime = Duration.ofSeconds(25);
+
+  @Test
+  @SneakyThrows
+  void waits_till_task_is_completed_for_ThreadPoolTaskScheduler() {
+    // GIVEN
+    AtomicBoolean isCompleted = new AtomicBoolean(false);
+    ThreadPoolTaskScheduler threadPoolTaskScheduler = new ThreadPoolTaskScheduler();
+    threadPoolTaskScheduler.initialize();
+    ScheduledThreadPoolExecutor internalExecutor = (ScheduledThreadPoolExecutor) threadPoolTaskScheduler.getScheduledExecutor();
+
+    threadPoolTaskScheduler.execute(() -> {
+      try {
+        Thread.sleep(submittedTaskRunTime.toMillis());
+        isCompleted.set(true);
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+    });
+
+    // wait till task is started before requesting shutdown
+    Awaitility.await().atMost(checkMaxWaitTime).until(() -> internalExecutor.getActiveCount() == 1);
+
+    // WHEN
+    ExecutorShutdownUtils.shutdownExecutor(threadPoolTaskScheduler, false);
+
+    // THEN
+    Awaitility.await().atMost(checkMaxWaitTime).until(isCompleted::get);
+    Awaitility.await().atMost(checkMaxWaitTime).until(() -> threadPoolTaskScheduler.getScheduledThreadPoolExecutor().isTerminated());
+  }
+
+  @Test
+  @SneakyThrows
+  void if_internal_scheduler_shutdown_first_ThreadPoolTaskScheduler_waits_till_task_is_completed() {
+    // GIVEN
+    AtomicBoolean isCompleted = new AtomicBoolean(false);
+    ThreadPoolTaskScheduler threadPoolTaskScheduler = new ThreadPoolTaskScheduler();
+    threadPoolTaskScheduler.initialize();
+    ScheduledThreadPoolExecutor internalExecutor = (ScheduledThreadPoolExecutor) threadPoolTaskScheduler.getScheduledExecutor();
+
+    threadPoolTaskScheduler.execute(() -> {
+      try {
+        Thread.sleep(submittedTaskRunTime.toMillis());
+        isCompleted.set(true);
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+    });
+
+    // wait till task is started before requesting shutdown
+    Awaitility.await().atMost(checkMaxWaitTime).until(() -> internalExecutor.getActiveCount() == 1);
+
+    // WHEN
+    ExecutorShutdownUtils.shutdownExecutor(internalExecutor, false);
+    ExecutorShutdownUtils.shutdownExecutor(threadPoolTaskScheduler, false);
+
+    // THEN
+    Awaitility.await().atMost(checkMaxWaitTime).until(isCompleted::get);
+    Awaitility.await().atMost(checkMaxWaitTime).until(internalExecutor::isTerminated);
+  }
+
+  @Test
+  void waits_till_task_is_completed_for_ConcurrentTaskScheduler() {
+    // GIVEN
+    AtomicBoolean isCompleted = new AtomicBoolean(false);
+    ConcurrentTaskScheduler concurrentTaskScheduler = new ConcurrentTaskScheduler();
+
+    concurrentTaskScheduler.execute(() -> {
+      try {
+        Thread.sleep(submittedTaskRunTime.toMillis());
+        isCompleted.set(true);
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+    });
+
+    // WHEN
+    ExecutorShutdownUtils.shutdownExecutor(concurrentTaskScheduler, false);
+
+    // THEN
+    Awaitility.await().atMost(checkMaxWaitTime).until(isCompleted::get);
+    Awaitility.await().atMost(checkMaxWaitTime).until(() -> {
+      Executor executor = concurrentTaskScheduler.getConcurrentExecutor();
+      if (executor instanceof ExecutorService) {
+        return ((ExecutorService) executor).isTerminated();
+      } else {
+        return true;
+      }
+    });
+  }
+
+  @Test
+  void waits_till_task_is_completed_for_ScheduledThreadPoolExecutor() {
+    // GIVEN
+    AtomicBoolean isCompleted = new AtomicBoolean(false);
+    ScheduledThreadPoolExecutor scheduledThreadPoolExecutor = new ScheduledThreadPoolExecutor(1);
+
+    scheduledThreadPoolExecutor.execute(() -> {
+      try {
+        Thread.sleep(submittedTaskRunTime.toMillis());
+        isCompleted.set(true);
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+    });
+
+    Awaitility.await().atMost(checkMaxWaitTime).until(() -> scheduledThreadPoolExecutor.getActiveCount() == 1);
+
+    // WHEN
+    ExecutorShutdownUtils.shutdownExecutor(scheduledThreadPoolExecutor, false);
+
+    // THEN
+    Awaitility.await().atMost(checkMaxWaitTime).until(isCompleted::get);
+    Awaitility.await().atMost(checkMaxWaitTime).until(scheduledThreadPoolExecutor::isTerminated);
+  }
+
+  @Test
+  void waits_till_task_is_completed_for_ExecutorService() {
+    // GIVEN
+    AtomicBoolean isCompleted = new AtomicBoolean(false);
+    ExecutorService executorService = Executors.newFixedThreadPool(1);
+
+    executorService.execute(() -> {
+      try {
+        Thread.sleep(submittedTaskRunTime.toMillis());
+        isCompleted.set(true);
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+    });
+
+    // WHEN
+    ExecutorShutdownUtils.shutdownExecutor(executorService, false);
+
+    // THEN
+    Awaitility.await().atMost(checkMaxWaitTime).until(isCompleted::get);
+    Awaitility.await().atMost(checkMaxWaitTime).until(executorService::isTerminated);
+  }
+}

--- a/core/src/test/resources/junit-platform.properties
+++ b/core/src/test/resources/junit-platform.properties
@@ -1,0 +1,1 @@
+junit.jupiter.execution.parallel.enabled = true

--- a/core/src/test2/java/com/transferwise/common/gracefulshutdown/strategies/ExecutorServiceGracefulShutdownStrategyIntTest.java
+++ b/core/src/test2/java/com/transferwise/common/gracefulshutdown/strategies/ExecutorServiceGracefulShutdownStrategyIntTest.java
@@ -1,0 +1,82 @@
+package com.transferwise.common.gracefulshutdown.strategies;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.transferwise.common.gracefulshutdown.GracefulShutdownHealthIndicator;
+import com.transferwise.common.gracefulshutdown.GracefulShutdownStrategiesRegistry;
+import com.transferwise.common.gracefulshutdown.GracefulShutdowner;
+import java.time.Duration;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.health.Status;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles({"test-fast-shutdown"})
+@SpringBootTest(classes = {ExecutorServiceGracefulShutdownStrategyIntTest.TestApplication.class})
+class ExecutorServiceGracefulShutdownStrategyIntTest {
+
+  @SpringBootApplication
+  @EnableScheduling
+  public static class TestApplication {
+
+    @Configuration
+    public static class ExecutorsConfig {
+
+      @Bean
+      ExecutorService getTestExecutorService() {
+        return Executors.newFixedThreadPool(1);
+      }
+    }
+  }
+
+  @Autowired
+  private GracefulShutdowner gracefulShutdowner;
+  @Autowired
+  private GracefulShutdownHealthIndicator healthIndicator;
+  @Autowired
+  ExecutorServiceGracefulShutdownStrategy executorServiceGracefulShutdownStrategy;
+  @Autowired
+  private GracefulShutdownStrategiesRegistry gracefulShutdownStrategiesRegistry;
+
+  @Autowired
+  private ExecutorService testExecutorService;
+
+  @Test
+  void test_when_task_is_running_longer_than_shutdown_timeout_then_interrupt() {
+    // GIVEN
+    assertThat(gracefulShutdowner.isRunning()).isTrue();
+    AtomicBoolean isTaskCompleted = new AtomicBoolean(false);
+    AtomicBoolean isTaskInterrupted = new AtomicBoolean(false);
+
+    assertThat(gracefulShutdownStrategiesRegistry.getStrategies().contains(executorServiceGracefulShutdownStrategy)).isTrue();
+    assertThat(healthIndicator.health().getStatus()).isEqualTo(Status.UP);
+    testExecutorService.execute(() -> {
+      try {
+        Thread.sleep(Duration.ofSeconds(20).toMillis());
+        isTaskCompleted.set(true);
+      } catch (InterruptedException e) {
+        isTaskInterrupted.set(true);
+      }
+    });
+
+    // WHEN
+    gracefulShutdowner.stop();
+
+    // THEN
+
+    assertThat(healthIndicator.health().getStatus()).isEqualTo(Status.DOWN);
+    assertThat(gracefulShutdowner.isRunning()).isFalse();
+    Awaitility.await().atMost(Duration.ofSeconds(2)).until(testExecutorService::isTerminated);
+    assertThat(isTaskCompleted.get()).isEqualTo(false);
+    assertThat(isTaskInterrupted.get()).isEqualTo(true);
+  }
+}

--- a/core/src/test2/java/com/transferwise/common/gracefulshutdown/strategies/TaskSchedulersGracefulShutdownStrategyIntTest.java
+++ b/core/src/test2/java/com/transferwise/common/gracefulshutdown/strategies/TaskSchedulersGracefulShutdownStrategyIntTest.java
@@ -1,0 +1,81 @@
+package com.transferwise.common.gracefulshutdown.strategies;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.transferwise.common.gracefulshutdown.GracefulShutdownHealthIndicator;
+import com.transferwise.common.gracefulshutdown.GracefulShutdownStrategiesRegistry;
+import com.transferwise.common.gracefulshutdown.GracefulShutdowner;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.health.Status;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.concurrent.ConcurrentTaskScheduler;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles({"test-fast-shutdown"})
+@SpringBootTest(classes = {TaskSchedulersGracefulShutdownStrategyIntTest.TestApplication.class})
+class TaskSchedulersGracefulShutdownStrategyIntTest {
+
+  @SpringBootApplication
+  @EnableScheduling
+  public static class TestApplication {
+
+    @Configuration
+    public static class ExecutorsConfig {
+
+      @Bean
+      ConcurrentTaskScheduler getConcurrentTaskScheduler() {
+        return new ConcurrentTaskScheduler();
+      }
+    }
+  }
+
+  @Autowired
+  private GracefulShutdowner gracefulShutdowner;
+  @Autowired
+  private GracefulShutdownHealthIndicator healthIndicator;
+  @Autowired
+  TaskSchedulersGracefulShutdownStrategy taskSchedulersGracefulShutdownStrategy;
+  @Autowired
+  private GracefulShutdownStrategiesRegistry gracefulShutdownStrategiesRegistry;
+
+  @Autowired
+  private ConcurrentTaskScheduler concurrentTaskScheduler;
+
+  @Test
+  @Disabled("Disabled: Test will fail. Created to show problem with current implementation.")
+  void test_when_task_is_running_longer_than_shutdown_timeout() {
+    // GIVEN
+    assertThat(gracefulShutdowner.isRunning()).isTrue();
+    AtomicBoolean isTaskCompletes = new AtomicBoolean(false);
+    AtomicBoolean isTaskInterrupted = new AtomicBoolean(false);
+
+    assertThat(gracefulShutdownStrategiesRegistry.getStrategies().contains(taskSchedulersGracefulShutdownStrategy)).isTrue();
+    assertThat(healthIndicator.health().getStatus()).isEqualTo(Status.UP);
+    concurrentTaskScheduler.execute(() -> {
+      try {
+        Thread.sleep(Duration.ofSeconds(20).toMillis());
+        isTaskCompletes.set(true);
+      } catch (InterruptedException e) {
+        isTaskInterrupted.set(true);
+      }
+    });
+
+    // WHEN
+    gracefulShutdowner.stop();
+
+    // THEN
+
+    assertThat(healthIndicator.health().getStatus()).isEqualTo(Status.DOWN);
+    assertThat(gracefulShutdowner.isRunning()).isFalse();
+    Awaitility.await().atMost(Duration.ofSeconds(5)).until(() -> isTaskCompletes.get() || isTaskInterrupted.get());
+  }
+}

--- a/core/src/test2/resources/application-test-fast-shutdown.yml
+++ b/core/src/test2/resources/application-test-fast-shutdown.yml
@@ -1,0 +1,4 @@
+tw-graceful-shutdown:
+  shutdownTimeoutMs: 1000
+  clientsReactionTimeMs: 1
+  strategiesCheckIntervalTimeMs: 100

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=2.8.1
+version=2.8.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=2.8.2
+version=2.9.0


### PR DESCRIPTION
## Context

<!-- Why is this PR necessary? If available, include links to a JIRA ticket or other relevant documentation. -->
This PR adds `ExecutorServiceGracefulShutdownStrategy`.

We already have implementation of graceful shutdown strategy for `TaskSchedulers`. But right now we are missing strategy for Java `ExecutorService`. 
Implementation uses Spring implementation of reactive streams - Project Reactor. Reactive Streams is part of Java since JDK 9(2017 year). Project Reactor is used in Spring since Spring 5.0(2017 year) and is a dependency for Spring WebFlux and WebClient for example. It simplifies non-blocking and async programming. Also allow to write code in clean functional style.

### Next steps:
`BaseReactiveResourceShutdownStrategy` will allow to implement graceful shutdown for reactor.core.scheduler.Scheduler. We implicitly use Scheduler if we use WebClient as it is used by WebClient under the hood.
Right now current version of reactor-core library in project don't allow this. Will be possible when project Spring version will use as dependency reactor-core library with version >= 3.5.0 (current is 3.4.16). Since 3.5.0 - Sheduler.disposeGracefully was introduced [version changelog](https://github.com/reactor/reactor-core/releases/tag/v3.5.0).


## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
