### PR TITLE
Refactor TaskSchedulersGracefulShutdownStrategy. Respect already submitted and running tasks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.10.0] - 2023-02-09
+
+### Changes
+
+* Refactor TaskSchedulersGracefulShutdownStrategy. Now it wait for published tasks to finish and force shutdown on timeout.
+
+
 ## [2.9.0] - 2023-01-19
 
 ### Changes

--- a/core/src/main/java/com/transferwise/common/gracefulshutdown/GracefulShutdownAutoConfiguration.java
+++ b/core/src/main/java/com/transferwise/common/gracefulshutdown/GracefulShutdownAutoConfiguration.java
@@ -88,8 +88,10 @@ public class GracefulShutdownAutoConfiguration {
   protected static class SpringTaskSchedulerConfiguration {
 
     @Bean
-    public TaskSchedulersGracefulShutdownStrategy taskSchedulersGracefulShutdownStrategy(@Autowired ApplicationContext applicationContext) {
-      return new TaskSchedulersGracefulShutdownStrategy(applicationContext);
+    public TaskSchedulersGracefulShutdownStrategy taskSchedulersGracefulShutdownStrategy(
+        @Autowired ApplicationContext applicationContext,
+        @Autowired GracefulShutdownProperties gracefulShutdownProperties) {
+      return new TaskSchedulersGracefulShutdownStrategy(applicationContext, gracefulShutdownProperties);
     }
   }
 
@@ -101,14 +103,16 @@ public class GracefulShutdownAutoConfiguration {
   protected static class SpringTaskSchedulerAlternativeConfiguration {
 
     @Bean
-    public TaskSchedulersGracefulShutdownStrategy taskSchedulersGracefulShutdownStrategy(@Autowired ApplicationContext applicationContext) {
-      return new TaskSchedulersGracefulShutdownStrategy(applicationContext);
+    public TaskSchedulersGracefulShutdownStrategy taskSchedulersGracefulShutdownStrategy(
+        @Autowired ApplicationContext applicationContext,
+        @Autowired GracefulShutdownProperties gracefulShutdownProperties) {
+      return new TaskSchedulersGracefulShutdownStrategy(applicationContext, gracefulShutdownProperties);
     }
 
     @Bean
     @Order
     public SchedulingConfigurer twGsSchedulingConfigurer(TaskSchedulersGracefulShutdownStrategy taskSchedulersGracefulShutdownStrategy) {
-      return taskRegistrar -> taskSchedulersGracefulShutdownStrategy.addTaskScheduler(taskRegistrar.getScheduler());
+      return taskRegistrar -> taskSchedulersGracefulShutdownStrategy.addResource(taskRegistrar.getScheduler());
     }
   }
 
@@ -117,10 +121,11 @@ public class GracefulShutdownAutoConfiguration {
   @ConditionalOnProperty(value = "tw-graceful-shutdown.executor-service.enabled", matchIfMissing = true)
   @ConditionalOnBean(java.util.concurrent.ExecutorService.class)
   protected static class ExecutorServiceGracefulShutdownStrategyConfiguration {
+
     @Bean
     public ExecutorServiceGracefulShutdownStrategy executorServiceGracefulShutdownStrategy(
-            @Autowired ApplicationContext applicationContext,
-            @Autowired GracefulShutdownProperties gracefulShutdownProperties
+        @Autowired ApplicationContext applicationContext,
+        @Autowired GracefulShutdownProperties gracefulShutdownProperties
     ) {
       return new ExecutorServiceGracefulShutdownStrategy(applicationContext, gracefulShutdownProperties);
     }

--- a/core/src/main/java/com/transferwise/common/gracefulshutdown/config/GracefulShutdownProperties.java
+++ b/core/src/main/java/com/transferwise/common/gracefulshutdown/config/GracefulShutdownProperties.java
@@ -13,4 +13,6 @@ public class GracefulShutdownProperties {
   private int clientsReactionTimeMs = 30_000;
 
   private int strategiesCheckIntervalTimeMs = 5_000;
+
+  private int resourceCheckIntervalTimeMs = 250;
 }

--- a/core/src/main/java/com/transferwise/common/gracefulshutdown/strategies/ExecutorServiceGracefulShutdownStrategy.java
+++ b/core/src/main/java/com/transferwise/common/gracefulshutdown/strategies/ExecutorServiceGracefulShutdownStrategy.java
@@ -12,8 +12,6 @@ import reactor.core.publisher.Mono;
 @Slf4j
 public class ExecutorServiceGracefulShutdownStrategy extends BaseReactiveResourceShutdownStrategy<ExecutorService> {
 
-  private final Duration delayBetweenTerminationCheck = Duration.ofMillis(250);
-
   @Override
   protected Duration getStrategyShutdownDelay() {
     // In case shutdown was called right after call to endpoint:
@@ -29,58 +27,27 @@ public class ExecutorServiceGracefulShutdownStrategy extends BaseReactiveResourc
     return Duration.ofMillis(getGracefulShutdownProperties().getClientsReactionTimeMs() + getResourceFullShutdownTimeoutMs() / 3);
   }
 
-  @Override
-  protected Duration getResourceGracefulShutdownTimeout() {
-    // getStrategyShutdownDelay time of getResourceFullShutdownTimeoutMs was already used.
-    // use 9/10 of remaining time for graceful shutdown
-    return Duration.ofMillis((getResourceFullShutdownTimeoutMs() - getStrategyShutdownDelay().toMillis()) / 10 * 9);
-  }
-
-  @Override
-  protected Duration getResourceForcedShutdownTimeout() {
-    // use remaining time for forced shutdown
-    return Duration.ofMillis((getResourceFullShutdownTimeoutMs() - getStrategyShutdownDelay().toMillis()) / 10);
-  }
-
   public ExecutorServiceGracefulShutdownStrategy(ApplicationContext applicationContext, GracefulShutdownProperties gracefulShutdownProperties) {
     super(ExecutorService.class, applicationContext, gracefulShutdownProperties);
   }
 
   @Override
   protected Mono<Void> shutdownResourceGraceful(@NonNull ExecutorService resource) {
-    return Mono.fromRunnable(() -> ExecutorShutdownUtils.shutdownExecutor(resource, true))
-        // Do not emit complete until ExecutorService termination
-        .then(waitTermination(resource));
+    return Mono.fromRunnable(() -> ExecutorShutdownUtils.shutdownExecutor(resource, true));
   }
 
   @Override
   protected Mono<Void> shutdownResourceForced(@NonNull ExecutorService resource) {
-    return Mono.fromRunnable(resource::shutdownNow)
-        .then(waitTermination(resource));
+    return Mono.fromRunnable(resource::shutdownNow);
   }
 
-  private Mono<Boolean> checkTermination(ExecutorService resource) {
+  @Override
+  protected Mono<Boolean> getResourceGracefulTerminationStatus(ExecutorService resource) {
     return Mono.fromCallable(resource::isTerminated);
   }
 
-  /**
-   * Will check for termination status in non-blocking way. No thread will be waiting.
-   *
-   * @param resource {@link ExecutorService} to wait for termination.
-   * @return {@link Mono} that will complete only when {@link #checkTermination} will return true
-   */
-  private Mono<Void> waitTermination(ExecutorService resource) {
-    return checkTermination(resource)
-        // Use expand as this allows to repeatedly call functions based on previous call result with a breadth-first approach.
-        // Call stack will not be polluted.
-        .expand(isTerminated -> {
-          if (!isTerminated) {
-            return checkTermination(resource)
-                .delaySubscription(this.delayBetweenTerminationCheck);
-          } else {
-            // Empty Mono signals as exit from expand
-            return Mono.empty();
-          }
-        }).then();
+  @Override
+  protected Mono<Boolean> getResourceForcedTerminationStatus(ExecutorService resource) {
+    return getResourceGracefulTerminationStatus(resource);
   }
 }

--- a/core/src/main/java/com/transferwise/common/gracefulshutdown/strategies/RequestCountGracefulShutdownStrategy.java
+++ b/core/src/main/java/com/transferwise/common/gracefulshutdown/strategies/RequestCountGracefulShutdownStrategy.java
@@ -18,9 +18,9 @@ public class RequestCountGracefulShutdownStrategy extends OncePerRequestFilter i
   private static final int SERVICE_UNAVAILABLE = 503;
   protected static final AtomicLong requestCount = new AtomicLong();
 
-  private boolean stopAcceptingRequests = false;
+  private volatile boolean stopAcceptingRequests = false;
 
-  private boolean stopCounting;
+  private volatile boolean stopCounting;
 
   @Autowired
   private RequestCountStrategyProperties requestCountStrategyProperties;

--- a/core/src/test/java/com/transferwise/common/gracefulshutdown/strategies/TaskSchedulersGracefulShutdownStrategyTest.java
+++ b/core/src/test/java/com/transferwise/common/gracefulshutdown/strategies/TaskSchedulersGracefulShutdownStrategyTest.java
@@ -1,26 +1,98 @@
 package com.transferwise.common.gracefulshutdown.strategies;
 
-import java.util.concurrent.Executors;
+import com.transferwise.common.gracefulshutdown.config.GracefulShutdownProperties;
+import com.transferwise.common.gracefulshutdown.utils.ExecutorShutdownUtils;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.context.support.StaticApplicationContext;
-import org.springframework.scheduling.concurrent.ConcurrentTaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
 class TaskSchedulersGracefulShutdownStrategyTest {
 
-  @Test
-  public void shutdown_invoked_on_private_classes() {
-    // GIVEN
-    var strategy = new TaskSchedulersGracefulShutdownStrategy(new StaticApplicationContext());
+  private static final Duration checkMaxWaitTime = Duration.ofSeconds(25);
 
-    var executor = Executors.newSingleThreadScheduledExecutor();
-    var scheduler = new ConcurrentTaskScheduler(executor);
-    strategy.addTaskScheduler(scheduler);
+  private static final GracefulShutdownProperties gracefulShutdownProperties;
+
+  static {
+    gracefulShutdownProperties = new GracefulShutdownProperties();
+    gracefulShutdownProperties.setShutdownTimeoutMs((int) Duration.ofSeconds(5).toMillis());
+    gracefulShutdownProperties.setClientsReactionTimeMs(100);
+  }
+
+  @Test
+  public void shutdown_invoked_on_application_context_classes() {
+    // GIVEN
+    StaticApplicationContext applicationContext = new StaticApplicationContext();
+    TaskSchedulersGracefulShutdownStrategy strategy = new TaskSchedulersGracefulShutdownStrategy(
+        applicationContext,
+        gracefulShutdownProperties
+    );
+    ThreadPoolTaskScheduler threadPoolTaskScheduler = new ThreadPoolTaskScheduler();
+    threadPoolTaskScheduler.initialize();
+    ConfigurableListableBeanFactory beanFactory = applicationContext.getBeanFactory();
+    beanFactory.registerSingleton("test", threadPoolTaskScheduler);
 
     // WHEN
     strategy.prepareForShutdown();
 
     // THEN
-    Awaitility.await().until(executor::isShutdown);
+    Awaitility.await().atMost(checkMaxWaitTime).until(() -> ExecutorShutdownUtils.isTerminated(threadPoolTaskScheduler));
+    Awaitility.await().atMost(checkMaxWaitTime).until(strategy::canShutdown);
+  }
+
+  @Test
+  public void shutdown_invoked_on_external_added_classes() {
+    // GIVEN
+    TaskSchedulersGracefulShutdownStrategy strategy = new TaskSchedulersGracefulShutdownStrategy(
+        new StaticApplicationContext(),
+        gracefulShutdownProperties
+    );
+    ThreadPoolTaskScheduler threadPoolTaskScheduler = new ThreadPoolTaskScheduler();
+    threadPoolTaskScheduler.initialize();
+    strategy.addTaskScheduler(threadPoolTaskScheduler);
+
+    // WHEN
+    strategy.prepareForShutdown();
+
+    // THEN
+    Awaitility.await().atMost(checkMaxWaitTime).until(() -> ExecutorShutdownUtils.isTerminated(threadPoolTaskScheduler));
+    Awaitility.await().atMost(checkMaxWaitTime).until(strategy::canShutdown);
+  }
+
+  @Test
+  public void shutdown_timeout_is_applied_and_called_shutdownNow() {
+    // GIVEN
+    AtomicBoolean isInterrupted = new AtomicBoolean(false);
+
+    TaskSchedulersGracefulShutdownStrategy strategy = new TaskSchedulersGracefulShutdownStrategy(
+        new StaticApplicationContext(),
+        gracefulShutdownProperties
+    );
+    ThreadPoolTaskScheduler threadPoolTaskScheduler = new ThreadPoolTaskScheduler();
+    threadPoolTaskScheduler.initialize();
+    strategy.addTaskScheduler(threadPoolTaskScheduler);
+    threadPoolTaskScheduler.execute(() -> {
+      try {
+        Thread.sleep(checkMaxWaitTime.toMillis());
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        isInterrupted.set(true);
+      }
+    });
+
+    // wait till task is started before requesting shutdown
+    Awaitility.await().atMost(checkMaxWaitTime).until(() -> threadPoolTaskScheduler.getActiveCount() == 1);
+
+    // WHEN
+    strategy.prepareForShutdown();
+
+    // THEN
+    Awaitility.await().atMost(checkMaxWaitTime).until(() -> ExecutorShutdownUtils.isTerminated(threadPoolTaskScheduler));
+    Awaitility.await().atMost(checkMaxWaitTime).until(strategy::canShutdown);
+    Assertions.assertTrue(isInterrupted.get());
   }
 }

--- a/core/src/test2/java/com/transferwise/common/gracefulshutdown/PlainGracefulShutdownerIntTest.java
+++ b/core/src/test2/java/com/transferwise/common/gracefulshutdown/PlainGracefulShutdownerIntTest.java
@@ -36,7 +36,7 @@ class PlainGracefulShutdownerIntTest {
     gracefulShutdowner.stop();
     long stopEndTimeMs = System.currentTimeMillis();
 
-    assertThat(stopEndTimeMs - stopStartTimeMs).as("No strategy is blocking").isLessThan(5_000);
+    assertThat(stopEndTimeMs - stopStartTimeMs).as("No strategy is blocking").isLessThan(6_000);
 
     assertThat(gracefulShutdowner.isRunning()).isFalse();
     assertThat(healthIndicator.health().getStatus()).isEqualTo(Status.DOWN);

--- a/core/src/test2/java/com/transferwise/common/gracefulshutdown/strategies/TaskSchedulersGracefulShutdownStrategyIntTest.java
+++ b/core/src/test2/java/com/transferwise/common/gracefulshutdown/strategies/TaskSchedulersGracefulShutdownStrategyIntTest.java
@@ -8,7 +8,6 @@ import com.transferwise.common.gracefulshutdown.GracefulShutdowner;
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.awaitility.Awaitility;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.health.Status;
@@ -51,11 +50,9 @@ class TaskSchedulersGracefulShutdownStrategyIntTest {
   private ConcurrentTaskScheduler concurrentTaskScheduler;
 
   @Test
-  @Disabled("Disabled: Test will fail. Created to show problem with current implementation.")
   void test_when_task_is_running_longer_than_shutdown_timeout() {
     // GIVEN
     assertThat(gracefulShutdowner.isRunning()).isTrue();
-    AtomicBoolean isTaskCompletes = new AtomicBoolean(false);
     AtomicBoolean isTaskInterrupted = new AtomicBoolean(false);
 
     assertThat(gracefulShutdownStrategiesRegistry.getStrategies().contains(taskSchedulersGracefulShutdownStrategy)).isTrue();
@@ -63,7 +60,6 @@ class TaskSchedulersGracefulShutdownStrategyIntTest {
     concurrentTaskScheduler.execute(() -> {
       try {
         Thread.sleep(Duration.ofSeconds(20).toMillis());
-        isTaskCompletes.set(true);
       } catch (InterruptedException e) {
         isTaskInterrupted.set(true);
       }
@@ -76,6 +72,6 @@ class TaskSchedulersGracefulShutdownStrategyIntTest {
 
     assertThat(healthIndicator.health().getStatus()).isEqualTo(Status.DOWN);
     assertThat(gracefulShutdowner.isRunning()).isFalse();
-    Awaitility.await().atMost(Duration.ofSeconds(5)).until(() -> isTaskCompletes.get() || isTaskInterrupted.get());
+    Awaitility.await().atMost(Duration.ofSeconds(5)).until(isTaskInterrupted::get);
   }
 }

--- a/core/src/test2/resources/application-test-fast-shutdown.yml
+++ b/core/src/test2/resources/application-test-fast-shutdown.yml
@@ -2,3 +2,4 @@ tw-graceful-shutdown:
   shutdownTimeoutMs: 1000
   clientsReactionTimeMs: 1
   strategiesCheckIntervalTimeMs: 100
+  resourceCheckIntervalTimeMs: 1

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=2.9.0
+version=2.10.0


### PR DESCRIPTION
## Context

<!-- Why is this PR necessary? If available, include links to a JIRA ticket or other relevant documentation. -->
There are 2 commits in this PR:

1. `TaskSchedulersGracefulShutdownStrategy`: Right now we consider this strategy as ready to shutdown as as soon as call a shutdown() on the executor. But already submitted tasks may still continue to work as shutdown() is not blocking and not waiting for actual termination. So we will return true on canShutdown() as soon as we call shutdown() on all executors. However already started tasks may still be running.
Test showing the problem is here: [test](https://github.com/transferwise/tw-graceful-shutdown/pull/28/files#diff-7471f978f32c87e51101d182547f9dfd512243ff69c3cce07ee0ef898f5a88ceL55)
Things to keep in mind:
We should consider case when task is unable to complete within reasonable amount of time. In that case we should force it to stop. For `ExecutorService` it is done with `shutdownNow()`. Note, that ideally task itself should be coded in a way prepared for interruption. But right now even if it is coded correctly - it will not receive signal to stop.
Current implementation will just close application after we call `shutdown()` on all task schedulers and wait for Shutdown timeout. This can lead to errors as we don't explicitly tell to tasks, that we plan to cancel them and just close the application on timeout. This implementation use the same approach as for `ExecutorServiceGracefulShutdownStrategy`.
Additionally for `ThreadPoolTaskScheduler` call to `threadPoolTaskScheduler.getScheduledThreadPoolExecutor().getQueue().clear()` is done in force shutdown part as this scheduler may be used as an executor for async processing with execute method. So clearing work queue right away might lead to some unexpected behaviour.
2. `RequestCountGracefulShutdownStrategy`: This commit simply add volatile to fields as each request could run in a dedicated thread or thread from thread pool. The main point is that this is different thread, so to not encounter memory visibility problems we should at least make those fields volatile.


## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
