### PR TITLE
Fix `UnboundConfigurationPropertiesException` when flag properties are set false.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.11.1] - 2023-05-18
+
+### Fixed
+* Fix for `UnboundConfigurationPropertiesException` when one of the autocofiguration conditional flag properties were set explicitly.
+e.g. `health-indicator.enabled: true` or `request-count-strategy.enabled: true`
+
 ## [2.11.0] - 2023-05-04
 
 ### Added

--- a/core/src/main/java/com/transferwise/common/gracefulshutdown/config/GracefulShutdownProperties.java
+++ b/core/src/main/java/com/transferwise/common/gracefulshutdown/config/GracefulShutdownProperties.java
@@ -7,6 +7,10 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @Data
 @SuppressWarnings("checkstyle:magicnumber")
 public class GracefulShutdownProperties {
+  @Data
+  public static class FlagProperty {
+    private boolean enabled;
+  }
 
   private int shutdownTimeoutMs = 90_000;
 
@@ -15,4 +19,10 @@ public class GracefulShutdownProperties {
   private int strategiesCheckIntervalTimeMs = 5_000;
 
   private int resourceCheckIntervalTimeMs = 250;
+
+  private FlagProperty healthIndicator;
+  private FlagProperty requestCountStrategy;
+  private FlagProperty kagkarlssonDbScheduler;
+  private FlagProperty springTaskScheduler;
+  private FlagProperty executorService;
 }

--- a/core/src/test/resources/application.yml
+++ b/core/src/test/resources/application.yml
@@ -12,3 +12,9 @@ tw-graceful-shutdown:
   shutdownTimeoutMs: 15000
   clientsReactionTimeMs: 1
   strategiesCheckIntervalTimeMs: 500
+
+  health-indicator.enabled: true
+  request-count-strategy.enabled: true
+  kagkarlsson-db-scheduler.enabled: true
+  spring-task-scheduler.enabled: true
+  executor-service.enabled: true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=2.11.0
+version=2.11.1


### PR DESCRIPTION
## Context

Right now you will get an exception if you try to set any of the fields controlling autoconfiguration.
With this changes you can do that.
`Caused by: org.springframework.boot.context.properties.bind.UnboundConfigurationPropertiesException: The elements [tw-graceful-shutdown.request-count-strategy.enabled] were left unbound.`

With this change those props can now be defined.
Note, that current behaviour of omitting them is still treating those props as true (due to `matchIfMissing`)

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
