### PR TITLE
Make executor service graceful shutdown disabled by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.12.0] - 2023-05-26
+* Do not enable `ExecutorServiceGracefulShutdownStrategy` by default.
+* Allow users to disable resources from being managed by graceful shutdown using `@GracefulShutdownIgnore` annotation
+
 ## [2.11.1] - 2023-05-18
 
 ### Fixed

--- a/core/src/main/java/com/transferwise/common/gracefulshutdown/GracefulShutdownAutoConfiguration.java
+++ b/core/src/main/java/com/transferwise/common/gracefulshutdown/GracefulShutdownAutoConfiguration.java
@@ -151,7 +151,7 @@ public class GracefulShutdownAutoConfiguration {
 
   @Configuration
   @ConditionalOnClass(name = "java.util.concurrent.ExecutorService")
-  @ConditionalOnProperty(value = "tw-graceful-shutdown.executor-service.enabled", matchIfMissing = true)
+  @ConditionalOnProperty(value = "tw-graceful-shutdown.executor-service.enabled", matchIfMissing = false)
   @ConditionalOnBean(java.util.concurrent.ExecutorService.class)
   protected static class ExecutorServiceGracefulShutdownStrategyConfiguration {
 

--- a/core/src/main/java/com/transferwise/common/gracefulshutdown/GracefulShutdownIgnore.java
+++ b/core/src/main/java/com/transferwise/common/gracefulshutdown/GracefulShutdownIgnore.java
@@ -1,0 +1,17 @@
+package com.transferwise.common.gracefulshutdown;
+
+import com.transferwise.common.gracefulshutdown.strategies.ExecutorServiceGracefulShutdownStrategy;
+import com.transferwise.common.gracefulshutdown.strategies.TaskSchedulersGracefulShutdownStrategy;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * Annotated Beans will not be shutdown gracefully by service.
+ * <p>
+ * Affects: {@link ExecutorServiceGracefulShutdownStrategy} and {@link TaskSchedulersGracefulShutdownStrategy}
+ * </p>
+ */
+@Retention(RetentionPolicy.RUNTIME)
+public @interface GracefulShutdownIgnore {
+
+}

--- a/core/src/test2/resources/application.yml
+++ b/core/src/test2/resources/application.yml
@@ -2,3 +2,5 @@ tw-graceful-shutdown:
   shutdownTimeoutMs: 15000
   clientsReactionTimeMs: 1
   strategiesCheckIntervalTimeMs: 500
+  executor-service:
+    enabled: true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=2.11.1
+version=2.12.0


### PR DESCRIPTION
## Context

<!-- Why is this PR necessary? If available, include links to a JIRA ticket or other relevant documentation. -->
Some users use `ExecutorService` Kafka topics listeners.
As they don't ave graceful shutdown strategy for Kafka listeners - `ExecutorService` is shutdown by `ExecutorServiceGracefulShutdownStrategy` before Kafka listeners and users encounter `java.util.concurrent.RejectedExecutionException`. Example: https://transferwise.atlassian.net/browse/SCREEN-2017

This PR solves this problem with 2 approaches:

1. It not enables `ExecutorServiceGracefulShutdownStrategy` by default. Users, who wish to safely shutdown `ExecutorService` can enable it by providing `tw-graceful-shutdown.executor-service.enabled: true`
2. Adds @GracefulShutdownIgnore annotation. Now users can enable this `ExecutorServiceGracefulShutdownStrategy` and still use it for all `ExecutorService` except those, annotated with @GracefulShutdownIgnore.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
