### PR TITLE
Fixes potential circular dependency between health indicator and other strategies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.14.1] - 2023-06-07
+
+### Fixed
+
+* Potential circular dependencies between custom strategies and strategies' registry.
+* A bug, where we tried to sort an immutable list, when ordering strategies.
+
 ## [2.14.0] - 2023-06-06
 
 ### Changed

--- a/core/src/main/java/com/transferwise/common/gracefulshutdown/GracefulShutdownHealthIndicator.java
+++ b/core/src/main/java/com/transferwise/common/gracefulshutdown/GracefulShutdownHealthIndicator.java
@@ -6,10 +6,20 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.health.AbstractHealthIndicator;
 import org.springframework.boot.actuate.health.Health;
+import org.springframework.context.annotation.Lazy;
 
 @Slf4j
 public class GracefulShutdownHealthIndicator extends AbstractHealthIndicator {
 
+  /*
+   * We need to access the registry in a lazy way, otherwise we may easily run into circular dependencies with other strategies.
+   * 
+   * E.g. some other strategy may inject something needing actuators, which in turn triggers creating the health indicators.
+   * 
+   * We could avoid this by for example sending out the list of all strategies in some callback method, e.g. "applicationStarted",
+   * but this solution seems a bit of over-engineering.
+   */
+  @Lazy
   @Autowired
   private GracefulShutdownStrategiesRegistry registry;
 

--- a/core/src/main/java/com/transferwise/common/gracefulshutdown/GracefulShutdowner.java
+++ b/core/src/main/java/com/transferwise/common/gracefulshutdown/GracefulShutdowner.java
@@ -1,12 +1,10 @@
 package com.transferwise.common.gracefulshutdown;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.transferwise.common.gracefulshutdown.config.GracefulShutdownProperties;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.InitializingBean;
@@ -50,7 +48,7 @@ public class GracefulShutdowner implements SmartLifecycle, InitializingBean {
     running = true;
 
     validateStrategies();
-    
+
     log.info("Notifying all strategies that the application has started.");
     var strategies = gracefulShutdownStrategiesRegistry.getStrategies();
     for (var strategy : strategies) {
@@ -75,7 +73,7 @@ public class GracefulShutdowner implements SmartLifecycle, InitializingBean {
 
       if (gracefulShutdownStrategiesRegistry instanceof DefaultGracefulShutdownStrategiesRegistry) {
         log.info("Replacing strategies with what we have now in app context.");
-        var strategiesInAppContextList = ImmutableList.copyOf(strategiesInAppContext);
+        var strategiesInAppContextList = new ArrayList<>(strategiesInAppContext);
         AnnotationAwareOrderComparator.sort(strategiesInAppContextList);
         ((DefaultGracefulShutdownStrategiesRegistry) gracefulShutdownStrategiesRegistry).setStrategies(strategiesInAppContextList);
       }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=2.14.0
+version=2.14.1


### PR DESCRIPTION
## Context

### Fixed

* Potential circular dependencies between custom strategies and strategies' registry.
* A bug, where we tried to sort an immutable list, when ordering strategies.


## Checklist
- [ ] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
