### PR TITLE
Check termination status for TaskSchedulerRouter instances correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.14.4] - 2024-04-10
+
+### Fixed
+
+* Check termination status for `TaskSchedulerRouter` instances correctly.
+
 ## [2.14.3] - 2024-02-22
 
 ### Changed

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=2.14.3
+version=2.14.4


### PR DESCRIPTION
## Context

Check termination status for TaskSchedulerRouter instances correctly.
Currently it's not checking the local executor and creates log noise.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
