### PR TITLE
[APPENG-849] Add support for spring boot 3.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,9 +18,8 @@ jobs:
       max-parallel: 100
       matrix:
         spring_boot_version:
+          - 3.3.1
           - 3.2.3
-          - 3.1.2
-          - 2.7.13
     env:
       SPRING_BOOT_VERSION: ${{ matrix.spring_boot_version }}
       RUNS_IN_CI: "true"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.14.5] - 2024-07-16
+
+### Added
+
+* Added support for spring boot 3.3
+
 ## [2.14.4] - 2024-04-10
 
 ### Fixed

--- a/build.libraries.gradle
+++ b/build.libraries.gradle
@@ -1,5 +1,5 @@
 ext {
-    springBootVersion = "${System.getenv("SPRING_BOOT_VERSION") ?: '2.7.13'}"
+    springBootVersion = "${System.getenv("SPRING_BOOT_VERSION") ?: '3.2.2'}"
 
     libraries = [
             // version defined

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=2.14.4
+version=2.14.5


### PR DESCRIPTION
## Context
This pull request attempts to upgrade the matrix tests to include spring boot 3.3 and remove 3.1 and 2.7
<!-- Why is this PR necessary? If available, include links to a JIRA ticket or other relevant documentation. -->

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 


## Details from ticket: [APPENG-849](https://transferwise.atlassian.net/browse/APPENG-849)

### Update platform libraries matrix tests to run with boot 3.3

>Tracking the specific libraries here:
>
>[https://docs.google.com/spreadsheets/d/1cogv7V6ofZv1urcBYYrj91f3VzKg-e92DltiiRgqndc/edit?gid=618138693#gid=618138693a|https://docs.google.com/spreadsheets/d/1cogv7V6ofZv1urcBYYrj91f3VzKg-e92DltiiRgqndc/edit?gid=618138693#gid=618138693a|smart-link] 


[APPENG-849]: https://transferwise.atlassian.net/browse/APPENG-849?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ