### PR TITLE
Update docs to reflect actual behaviour

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -47,10 +47,11 @@ When set to `true` or left unset, it creates the `TaskSchedulersGracefulShutdown
 ```yaml
 tw-graceful-shutdown:
   executor-service:
-    enabled: [true|false] # default is true
+    enabled: [true|false] # default is false
 ```
 
-When set to `true` or left unset, it creates the `ExecutorServiceGracefulShutdownStrategy` bean conditionally on the presence of the `java.util.concurrent.ExecutorService` class.
+When set to `true`, it creates the `ExecutorServiceGracefulShutdownStrategy` bean conditionally on the presence of the `java.util.concurrent.ExecutorService` class.
+The default was changed to `false` in this PR: https://github.com/transferwise/tw-graceful-shutdown/pull/37
 
 ### Request Count Strategy
 ```yaml


### PR DESCRIPTION
## Context

Default behaviour of enabling the graceful shutdown strategy for executor service beans was changed in this PR.
https://github.com/transferwise/tw-graceful-shutdown/pull/37
Update docs to reflect the change.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
